### PR TITLE
Some small improvements to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         pytest --cov=allennlp_models/ --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python }} == 3.7
+      if: ${{ matrix.python }} == '3.7'
       uses: codecov/codecov-action@v1.0.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7]
+        python: ['3.6', '3.7']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     branches:
     - master
   schedule:
-    - cron: '0 10 * * *' # run at 10 AM UTC every day.
+    - cron: '17 10 * * *' # run at 10 AM UTC every day.
 
 jobs:
   build:
@@ -35,8 +35,8 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade git+https://github.com/allenai/allennlp.git@master
-        pip install -r requirements.txt
-        pip install -r dev-requirements.txt
+        pip install --upgrade -r requirements.txt
+        pip install --upgrade -r dev-requirements.txt
 
     - name: Lint
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,13 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Install requirements
       run: |
         pip install -r requirements.txt
-        pip install pytest pytest-cov flake8 black mypy
+        pip install -r dev-requirements.txt
     - name: Lint
       run: |
         flake8 -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,18 +38,21 @@ jobs:
         pip install --upgrade -r <(grep -Ev '^allennlp$' requirements.txt)
         pip install --upgrade -r dev-requirements.txt
 
+    - name: Show pip freeze
+      run: |
+        pip freeze
+
     - name: Lint
       run: |
-        flake8 -v
-        black -v --check .
+        make lint
 
     - name: Type check
       run: |
-        mypy allennlp_models --ignore-missing-imports --no-strict-optional --no-site-packages
+        make typecheck
 
     - name: Run tests
       run: |
-        pytest --cov=allennlp_models/ --cov-report=xml
+        make test-with-cov
 
     - name: Upload coverage to Codecov
       if: matrix.python == '3.7'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
     - master
   schedule:
     - cron: '0 10 * * *' # run at 10 AM UTC every day.
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -56,3 +58,32 @@ jobs:
       uses: codecov/codecov-action@v1.0.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  deploy:
+    needs: build
+    if: github.event_name == 'release' && github.repository == 'allenai/allennlp-models'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install requirements
+      run: |
+        pip install -e .
+        pip install -r dev-requirements.txt
+
+    - name: Build Package
+      run: |
+        python setup.py bdist_wheel sdist
+
+    - name: Upload to PyPI
+      env:
+        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
 
     - name: Install requirements
       run: |
+        pip install --upgrade git+https://github.com/allenai/allennlp.git@master
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
     - master
+  schedule:
+    - cron: '0 10 * * *' # run at 10 AM UTC every day.
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,15 +23,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-    - name: Test if condition
-      if: matrix.python == '3.7'
-      run:
-        echo ${{ matrix.python }}
-
-    - name: Exit early
-      run:
-        exit 1
-
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
@@ -58,7 +49,7 @@ jobs:
         pytest --cov=allennlp_models/ --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python }} == '3.7'
+      if: matrix.python == '3.7'
       uses: codecov/codecov-action@v1.0.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   pull_request:
     branches:
@@ -6,36 +7,49 @@ on:
   push:
     branches:
     - master
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.6, 3.7]
+
     steps:
     - uses: actions/checkout@v1
+
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python }}
+
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-pip-${{ matrix.python }}
+
     - name: Install requirements
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
+
     - name: Lint
       run: |
         flake8 -v
         black -v --check .
+
     - name: Type check
       run: |
         mypy allennlp_models --ignore-missing-imports --no-strict-optional --no-site-packages
+
     - name: Run tests
       run: |
         pytest --cov=allennlp_models/ --cov-report=xml
+
     - name: Upload coverage to Codecov
+      if: ${{ matrix.python }} == 3.7
       uses: codecov/codecov-action@v1.0.2
       with:
-        token: da233513-af22-4b18-a7c4-e70467fc05e3
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,15 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
+    - name: Test if condition
+      if: ${{ matrix.python }} == '3.7'
+      run:
+        echo ${{ matrx.python }}
+
+    - name: Exit early
+      run:
+        exit 1
+
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Test if condition
       if: ${{ matrix.python }} == '3.7'
       run:
-        echo ${{ matrx.python }}
+        echo ${{ matrix.python }}
 
     - name: Exit early
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,6 @@ on:
     - master
   schedule:
     - cron: '0 10 * * *' # run at 10 AM UTC every day.
-  release:
-    types: [published]
 
 jobs:
   build:
@@ -58,32 +56,3 @@ jobs:
       uses: codecov/codecov-action@v1.0.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-
-  deploy:
-    needs: build
-    if: github.event_name == 'release' && github.repository == 'allenai/allennlp-models'
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-
-    - name: Install requirements
-      run: |
-        pip install -e .
-        pip install -r dev-requirements.txt
-
-    - name: Build Package
-      run: |
-        python setup.py bdist_wheel sdist
-
-    - name: Upload to PyPI
-      env:
-        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade git+https://github.com/allenai/allennlp.git@master
-        pip install --upgrade -r requirements.txt
+        pip install --upgrade -r <(grep -Ev '^allennlp$' requirements.txt)
         pip install --upgrade -r dev-requirements.txt
 
     - name: Lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Test if condition
-      if: ${{ matrix.python }} == '3.7'
+      if: matrix.python == '3.7'
       run:
         echo ${{ matrix.python }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,15 @@ jobs:
 
     - name: Lint
       run: |
-        flake8 -v
-        black -v --check .
+        make lint
 
     - name: Type check
       run: |
-        mypy allennlp_models --ignore-missing-imports --no-strict-optional --no-site-packages
+        make typecheck
 
     - name: Run tests
       run: |
-        pytest -v
+        make test
 
     - name: Build Package
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: PyPI Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    needs: build
+    if: github.repository == 'allenai/allennlp-models'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install requirements
+      run: |
+        pip install -e .
+        pip install -r dev-requirements.txt
+
+    - name: Lint
+      run: |
+        flake8 -v
+        black -v --check .
+
+    - name: Type check
+      run: |
+        mypy allennlp_models --ignore-missing-imports --no-strict-optional --no-site-packages
+
+    - name: Run tests
+      run: |
+        pytest -v
+
+    - name: Build Package
+      run: |
+        python setup.py bdist_wheel sdist
+
+    - name: Upload to PyPI
+      env:
+        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY : lint
+lint :
+	flake8 -v
+	black -v --check .
+
+.PHONY : typecheck
+typecheck :
+	mypy allennlp_models --ignore-missing-imports --no-strict-optional --no-site-packages
+
+.PHONY : test
+test :
+	pytest -v --color=yes
+
+.PHONY : test-with-cov
+test-with-cov :
+	pytest -v --color=yes --cov=allennlp_models/ --cov-report=xml

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,13 +4,13 @@
 flake8
 
 # Static type checking
-mypy==0.761
+mypy==0.770
 
 # Automatic code formatting
 black
 
 # For creating git precommit hooks
-pre-commit==2.1.1
+pre-commit==2.2.0
 
 # Allows generation of coverage reports with pytest.
 pytest-cov
@@ -18,19 +18,6 @@ pytest-cov
 # Allows codecov to generate coverage reports
 coverage
 codecov
-
-# Required to run sanic tests
-aiohttp
-
-#### DOC-RELATED PACKAGES ####
-
-# YAML manipulation
-ruamel.yaml
-
-mathy_pydoc>=0.6.7,<0.7.0
-markdown-include==0.5.1
-# Package for the material theme for mkdocs
-mkdocs-material==4.6.3
 
 #### PACKAGE-UPLOAD PACKAGES ####
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-# To be changed to allennlp>=1.0 once that's released.
-git+https://github.com/allenai/allennlp.git@6056f1a12110990ae21fe4b62bf106d388e5d149
-
+allennlp
 # For RC models
 word2number>=1.1
 py-rouge==1.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("allennlp_models/version.py") as version_file:
 # cross-library integration testing.
 with open("requirements.txt") as requirements_file:
     install_requirements = requirements_file.readlines()
-    install_requirements = [r for r in install_requirements if "allennlp" not in r]
+    install_requirements = [r for r in install_requirements if r != "allennlp"]
     if not os.environ.get("EXCLUDE_ALLENNLP_IN_SETUP"):
         requirement = f"allennlp=={VERSION['VERSION']}"
         install_requirements.append(requirement)

--- a/setup.py
+++ b/setup.py
@@ -25,22 +25,9 @@ with open("allennlp_models/version.py") as version_file:
 # cross-library integration testing.
 with open("requirements.txt") as requirements_file:
     install_requirements = requirements_file.readlines()
-    install_requirements = [
-        r for r in install_requirements if "git+https://github.com/allenai/allennlp" not in r
-    ]
+    install_requirements = [r for r in install_requirements if "allennlp" not in r]
     if not os.environ.get("EXCLUDE_ALLENNLP_IN_SETUP"):
-        # Warning: This will not give you the desired version if you've already
-        # installed allennlp! See https://github.com/pypa/pip/issues/5898.
-        #
-        # There used to be an alternative to this using `dependency_links`
-        # (https://stackoverflow.com/questions/3472430), but pip decided to
-        # remove this in version 19 breaking numerous projects in the process.
-        # See https://github.com/pypa/pip/issues/6162.
-        #
-        # As a mitigation, run `pip uninstall allennlp` before installing this
-        # package.
-        sha = "6056f1a12110990ae21fe4b62bf106d388e5d149"
-        requirement = f"allennlp @ git+https://github.com/allenai/allennlp@{sha}#egg=allennlp"
+        requirement = f"allennlp=={VERSION['VERSION']}"
         install_requirements.append(requirement)
 
 # make pytest-runner a conditional requirement,


### PR DESCRIPTION
- Builds in Python 3.6 and 3.7 in parallel.
- Removes codecov secret from config (it was the wrong token anyway).
- Caches against dev-requirements.txt.
- Pins allennlp to matching version in `setup.py`, but unpins in requirements and always installed latest from master branch in CI.
- Adds a nightly build schedule.
- Adds a PyPI release workflow triggered on GitHub release