### PR TITLE
make transformer qa predictor consistent with other rc predictors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Moved the models into categories based on their format
+### Changed
+
+- Moved the models into categories based on their format
+
+### Fixed
+
+- Made `transformer_qa` predictor accept JSON input with the keys "question" and "passage" to be consistent with the `reading-comprehension` predictor.
 
 ## [v1.0.0rc4](https://github.com/allenai/allennlp-models/releases/tag/v1.0.0rc4) - 2019-05-14
 

--- a/allennlp_models/rc/predictors/transformer_qa.py
+++ b/allennlp_models/rc/predictors/transformer_qa.py
@@ -57,7 +57,7 @@ class TransformerQAPredictor(Predictor):
                 qid=str(self._next_qid),
                 question=json_dict["question"],
                 answers=[],
-                context=json_dict["context"],
+                context=json_dict.get("passage", json_dict["context"]),
                 first_answer_offset=None,
             )
         )


### PR DESCRIPTION
This is needed in order to easily add transformer-qa to the demo.