### PR TITLE
fixes on some structured prediction dataset readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Nothing yet
+- Added option to SemanticDependenciesDatasetReader to not skip instances that have no arcs, for validation data.
 
 ## [v1.0.0rc5](https://github.com/allenai/allennlp-models/releases/tag/v1.0.0rc5) - 2020-05-14
 

--- a/allennlp_models/structured_prediction/dataset_readers/semantic_dependencies.py
+++ b/allennlp_models/structured_prediction/dataset_readers/semantic_dependencies.py
@@ -83,11 +83,18 @@ class SemanticDependenciesDatasetReader(DatasetReader):
 
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
         The token indexers to be applied to the words TextField.
+    skip_when_no_arcs : `bool`, optional (default=`True`)
+        If this is true, skip examples containing no semantic arcs.
     """
 
-    def __init__(self, token_indexers: Dict[str, TokenIndexer] = None, **kwargs) -> None:
+    def __init__(
+        self,
+        token_indexers: Dict[str, TokenIndexer] = None,
+        skip_when_no_arcs = True,
+        **kwargs) -> None:
         super().__init__(**kwargs)
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
+        self._skip_when_no_arcs = skip_when_no_arcs
 
     @overrides
     def _read(self, file_path: str):
@@ -99,7 +106,7 @@ class SemanticDependenciesDatasetReader(DatasetReader):
         with open(file_path) as sdp_file:
             for annotated_sentence, directed_arc_indices, arc_tags in lazy_parse(sdp_file.read()):
                 # If there are no arc indices, skip this instance.
-                if not directed_arc_indices:
+                if self._skip_when_no_arcs and not directed_arc_indices:
                     continue
                 tokens = [word["form"] for word in annotated_sentence]
                 pos_tags = [word["pos"] for word in annotated_sentence]

--- a/allennlp_models/structured_prediction/dataset_readers/semantic_dependencies.py
+++ b/allennlp_models/structured_prediction/dataset_readers/semantic_dependencies.py
@@ -90,8 +90,9 @@ class SemanticDependenciesDatasetReader(DatasetReader):
     def __init__(
         self,
         token_indexers: Dict[str, TokenIndexer] = None,
-        skip_when_no_arcs = True,
-        **kwargs) -> None:
+        skip_when_no_arcs: bool = True,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._skip_when_no_arcs = skip_when_no_arcs

--- a/allennlp_models/structured_prediction/dataset_readers/universal_dependencies.py
+++ b/allennlp_models/structured_prediction/dataset_readers/universal_dependencies.py
@@ -111,7 +111,7 @@ class UniversalDependenciesDatasetReader(DatasetReader):
                 [x[0] for x in dependencies], text_field, label_namespace="head_tags"
             )
             fields["head_indices"] = SequenceLabelField(
-                [x[1] for x in dependencies], text_field, label_namespace="head_index_tags"
+                [x[1] for x in dependencies], text_field, label_namespace="head_indeices"
             )
 
         fields["metadata"] = MetadataField({"words": words, "pos": upos_tags})

--- a/allennlp_models/structured_prediction/dataset_readers/universal_dependencies.py
+++ b/allennlp_models/structured_prediction/dataset_readers/universal_dependencies.py
@@ -111,7 +111,7 @@ class UniversalDependenciesDatasetReader(DatasetReader):
                 [x[0] for x in dependencies], text_field, label_namespace="head_tags"
             )
             fields["head_indices"] = SequenceLabelField(
-                [x[1] for x in dependencies], text_field, label_namespace="head_indeices"
+                [x[1] for x in dependencies], text_field, label_namespace="head_index_tags"
             )
 
         fields["metadata"] = MetadataField({"words": words, "pos": upos_tags})

--- a/training_config/structured_prediction/semantic_dependencies.json
+++ b/training_config/structured_prediction/semantic_dependencies.json
@@ -2,7 +2,7 @@
     "dataset_reader":{
         "type":"semantic_dependencies"
     },
-    "dataset_reader":{
+    "validation_dataset_reader":{
         "type":"semantic_dependencies",
         "skip_when_no_arcs": false
     },

--- a/training_config/structured_prediction/semantic_dependencies.json
+++ b/training_config/structured_prediction/semantic_dependencies.json
@@ -2,6 +2,10 @@
     "dataset_reader":{
         "type":"semantic_dependencies"
     },
+    "dataset_reader":{
+        "type":"semantic_dependencies",
+        "skip_when_no_arcs": false
+    },
     "train_data_path": "/home/markn/data/semantic_dependency_parsing/semeval2015_data/dm/data/english/english_dm_augmented_train.sdp",
     "validation_data_path": "/home/markn/data/semantic_dependency_parsing/semeval2015_data/dm/data/english/english_dm_augmented_dev.sdp",
     "test_data_path": "/home/markn/data/semantic_dependency_parsing/semeval2015_data/dm/data/english/english_id_dm_augmented_test.sdp",
@@ -35,15 +39,18 @@
       "tag_representation_dim": 100,
       "dropout": 0.3,
       "input_dropout": 0.3,
-      "initializer": [
-        [".*feedforward.*weight", {"type": "xavier_uniform"}],
-        [".*feedforward.*bias", {"type": "zero"}],
-        [".*tag_bilinear.*weight", {"type": "xavier_uniform"}],
-        [".*tag_bilinear.*bias", {"type": "zero"}],
-        [".*weight_ih.*", {"type": "xavier_uniform"}],
-        [".*weight_hh.*", {"type": "orthogonal"}],
-        [".*bias_ih.*", {"type": "zero"}],
-        [".*bias_hh.*", {"type": "lstm_hidden_bias"}]]
+      "initializer": {
+        "regexes": [
+          [".*feedforward.*weight", {"type": "xavier_uniform"}],
+          [".*feedforward.*bias", {"type": "zero"}],
+          [".*tag_bilinear.*weight", {"type": "xavier_uniform"}],
+          [".*tag_bilinear.*bias", {"type": "zero"}],
+          [".*weight_ih.*", {"type": "xavier_uniform"}],
+          [".*weight_hh.*", {"type": "orthogonal"}],
+          [".*bias_ih.*", {"type": "zero"}],
+          [".*bias_hh.*", {"type": "lstm_hidden_bias"}]
+        ]
+      }
     },
 
     "data_loader": {


### PR DESCRIPTION
Hello, thank you for sharing the great codebase! I am currently using the syntactic and semantic dependency parsers in this repo in my project and noticed some minor bugs.

- **incorrect `label_namespace` in `UniversalDependenciesDatasetReader`**: since `label_namespace` for `head_indices` (syntactic heads) is set to `head_index_tags`, these are treated as *tags*, resulting in the creation of the corresponding namespace in vocabulary with entries of numbers (head indices). Additionally, I observed inaccurate training results of a  biaffine model with this setting, while after fixing this, the training went good. I believe the `label_namespace`'s name for this used to be `head_indices`, so I suggest to return this back to the original name.

- **`skip_when_no_arcs` optional argument in `SemanticDependenciesDatasetReader`**: In the original implementation of this class, examples with no annotated semantic dependencies are discarded. This is fine for the training split, but it discards some examples in the validation/test sets, and results in inaccurate metric calculation. I suggest to add a new `skip_when_no_arcs` optional argument to control if to discard those examples, and set `validation_dataset_reader` with this key set false in the config json file.

Lastly I fixed the "initializer" part of `semantic_dependencies.json` to adapt to newer way of configuring this.