### PR TITLE
Fix the initializer of BIMPM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CopyNetSeq2Seq` model now works with pretrained transformers.
 - A bug with `NextTokenLM` that caused simple gradient interpreters to fail.
-- A bug in `training_config` of `qanet` that used the old version of `regularizer`.
+- A bug in `training_config` of `qanet` and `bimpm` that used the old version of `regularizer` and `initializer`.
 
 ### Changed
 

--- a/training_config/pair_classification/bimpm.jsonnet
+++ b/training_config/pair_classification/bimpm.jsonnet
@@ -100,14 +100,16 @@
       "activations": ["relu", "linear"],
       "dropout": [0.1, 0.0]
     },
-    "initializer": [
-      [".*linear_layers.*weight", {"type": "xavier_normal"}],
-      [".*linear_layers.*bias", {"type": "constant", "val": 0}],
-      [".*weight_ih.*", {"type": "xavier_normal"}],
-      [".*weight_hh.*", {"type": "orthogonal"}],
-      [".*bias.*", {"type": "constant", "val": 0}],
-      [".*matcher.*match_weights.*", {"type": "kaiming_normal"}]
-    ]
+    "initializer": {
+      "regexes": [
+        [".*linear_layers.*weight", {"type": "xavier_normal"}],
+        [".*linear_layers.*bias", {"type": "constant", "val": 0}],
+        [".*weight_ih.*", {"type": "xavier_normal"}],
+        [".*weight_hh.*", {"type": "orthogonal"}],
+        [".*bias.*", {"type": "constant", "val": 0}],
+        [".*matcher.*match_weights.*", {"type": "kaiming_normal"}]
+      ]
+    }
   },
   "data_loader": {
     "batch_sampler": {


### PR DESCRIPTION
Similar issue with allenai/allennlp#4419

BIMPM in allennlp-models still used the old version of initializer. (But the `experiment.json` in the `test_fixtures` is right, see https://github.com/allenai/allennlp-models/blob/master/test_fixtures/pair_classification/bimpm/experiment.json)

I am now upgrading our code from `allennlp<=0.9.0` to `allennlp==1.0.0`. 

Thanks for your great work in the latest version. 