### PR TITLE
Update some models for AMP training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `CopyNet` model now works with AMP.
+
 ## [v1.1.0rc2](https://github.com/allenai/allennlp-models/releases/tag/v1.1.0rc2) - 2020-07-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `CopyNet` model now works with AMP.
+- `CopyNet` and `SimpleSeq2Seq` models now work with AMP.
 
 ## [v1.1.0rc2](https://github.com/allenai/allennlp-models/releases/tag/v1.1.0rc2) - 2020-07-31
 

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -336,7 +336,7 @@ class CopyNetSeq2Seq(Model):
         # shape: (group_size, decoder_input_dim)
         projected_decoder_input = self._input_projection_layer(decoder_input)
 
-        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for RNNs.
+        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for LSTMCells.
         with torch.cuda.amp.autocast(False):
             state["decoder_hidden"], state["decoder_context"] = self._decoder_cell(
                 projected_decoder_input.float(),

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -339,7 +339,8 @@ class CopyNetSeq2Seq(Model):
         # TODO (epwalsh): revert this once torch's AMP is working for RNNs.
         with torch.cuda.amp.autocast(False):
             state["decoder_hidden"], state["decoder_context"] = self._decoder_cell(
-                projected_decoder_input.float(), (state["decoder_hidden"], state["decoder_context"])
+                projected_decoder_input.float(),
+                (state["decoder_hidden"].float(), state["decoder_context"].float()),
             )
 
         return state

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -336,7 +336,7 @@ class CopyNetSeq2Seq(Model):
         # shape: (group_size, decoder_input_dim)
         projected_decoder_input = self._input_projection_layer(decoder_input)
 
-        # TODO (epwalsh): revert this once torch's AMP is working for RNNs.
+        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for RNNs.
         with torch.cuda.amp.autocast(False):
             state["decoder_hidden"], state["decoder_context"] = self._decoder_cell(
                 projected_decoder_input.float(),

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -336,9 +336,12 @@ class CopyNetSeq2Seq(Model):
         # shape: (group_size, decoder_input_dim)
         projected_decoder_input = self._input_projection_layer(decoder_input)
 
-        state["decoder_hidden"], state["decoder_context"] = self._decoder_cell(
-            projected_decoder_input, (state["decoder_hidden"], state["decoder_context"])
-        )
+        # TODO (epwalsh): revert this once torch's AMP is working for RNNs.
+        with torch.cuda.amp.autocast(False):
+            state["decoder_hidden"], state["decoder_context"] = self._decoder_cell(
+                projected_decoder_input.float(), (state["decoder_hidden"], state["decoder_context"])
+            )
+
         return state
 
     def _get_generation_scores(self, state: Dict[str, torch.Tensor]) -> torch.Tensor:

--- a/allennlp_models/generation/models/simple_seq2seq.py
+++ b/allennlp_models/generation/models/simple_seq2seq.py
@@ -434,7 +434,7 @@ class SimpleSeq2Seq(Model):
         # shape (decoder_hidden): (batch_size, decoder_output_dim)
         # shape (decoder_context): (batch_size, decoder_output_dim)
 
-        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for RNNs.
+        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for LSTMCells.
         with torch.cuda.amp.autocast(False):
             decoder_hidden, decoder_context = self._decoder_cell(
                 decoder_input.float(), (decoder_hidden.float(), decoder_context.float())

--- a/allennlp_models/generation/models/simple_seq2seq.py
+++ b/allennlp_models/generation/models/simple_seq2seq.py
@@ -433,9 +433,12 @@ class SimpleSeq2Seq(Model):
 
         # shape (decoder_hidden): (batch_size, decoder_output_dim)
         # shape (decoder_context): (batch_size, decoder_output_dim)
-        decoder_hidden, decoder_context = self._decoder_cell(
-            decoder_input, (decoder_hidden, decoder_context)
-        )
+
+        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for RNNs.
+        with torch.cuda.amp.autocast(False):
+            decoder_hidden, decoder_context = self._decoder_cell(
+                decoder_input.float(), (decoder_hidden.float(), decoder_context.float())
+            )
 
         state["decoder_hidden"] = decoder_hidden
         state["decoder_context"] = decoder_context

--- a/allennlp_models/generation/modules/decoder_nets/lstm_cell.py
+++ b/allennlp_models/generation/modules/decoder_nets/lstm_cell.py
@@ -126,9 +126,11 @@ class LstmCellDecoderNet(DecoderNet):
 
         # shape (decoder_hidden): (batch_size, decoder_output_dim)
         # shape (decoder_context): (batch_size, decoder_output_dim)
-        decoder_hidden, decoder_context = self._decoder_cell(
-            decoder_input, (decoder_hidden, decoder_context)
-        )
+        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for RNNs.
+        with torch.cuda.amp.autocast(False):
+            decoder_hidden, decoder_context = self._decoder_cell(
+                decoder_input.float(), (decoder_hidden.float(), decoder_context.float())
+            )
 
         return (
             {"decoder_hidden": decoder_hidden, "decoder_context": decoder_context},

--- a/allennlp_models/generation/modules/decoder_nets/lstm_cell.py
+++ b/allennlp_models/generation/modules/decoder_nets/lstm_cell.py
@@ -126,7 +126,7 @@ class LstmCellDecoderNet(DecoderNet):
 
         # shape (decoder_hidden): (batch_size, decoder_output_dim)
         # shape (decoder_context): (batch_size, decoder_output_dim)
-        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for RNNs.
+        # TODO (epwalsh): remove the autocast(False) once torch's AMP is working for LSMTCells.
         with torch.cuda.amp.autocast(False):
             decoder_hidden, decoder_context = self._decoder_cell(
                 decoder_input.float(), (decoder_hidden.float(), decoder_context.float())

--- a/tests/generation/models/copynet_test.py
+++ b/tests/generation/models/copynet_test.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.special import logsumexp
 import torch
 
+from allennlp.commands.train import train_model_from_file
 from allennlp.common.testing import ModelTestCase, requires_gpu
 
 from allennlp_models.generation import CopyNetDatasetReader, CopyNetSeq2Seq  # noqa: F401
@@ -20,11 +21,11 @@ class CopyNetTest(ModelTestCase):
         self.ensure_model_can_train_save_and_load(self.param_file, tolerance=1e-2)
 
     @requires_gpu
-    def test_model_can_train_save_load_with_amp(self):
-        self.ensure_model_can_train_save_and_load(
+    def test_model_can_train_with_amp(self):
+        train_model_from_file(
             self.param_file,
-            tolerance=1e-2,
-            overrides="{'trainer.use_amp':true, 'trainer.cuda_device':0}",
+            self.TEST_DIR,
+            overrides="{'trainer.use_amp':true,'trainer.cuda_device':0}",
         )
 
     def test_vocab(self):

--- a/tests/generation/models/copynet_test.py
+++ b/tests/generation/models/copynet_test.py
@@ -29,7 +29,7 @@ class CopyNetTest(ModelTestCase):
             overrides="{'trainer.use_amp':true,'trainer.cuda_device':0}",
         )
 
-        # NOTE: as of writing this test, AMP does not work with RNNs. Hence we had
+        # NOTE: as of writing this test, AMP does not work with RNNs and LSTMCells. Hence we had
         # to wrap the call to LSTMCell() in CopyNet (and other models) within an autocast(False) context.
         # But if this part of the test fails, i.e. a RuntimeError is never raised,
         # that means AMP may be working now with RNNs, in which case we can remove

--- a/tests/generation/models/copynet_test.py
+++ b/tests/generation/models/copynet_test.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.special import logsumexp
 import torch
 
-from allennlp.common.testing import ModelTestCase
+from allennlp.common.testing import ModelTestCase, requires_gpu
 
 from allennlp_models.generation import CopyNetDatasetReader, CopyNetSeq2Seq  # noqa: F401
 from tests import FIXTURES_ROOT
@@ -16,8 +16,16 @@ class CopyNetTest(ModelTestCase):
             FIXTURES_ROOT / "generation" / "copynet" / "data" / "copyover.tsv",
         )
 
-    def test_model_can_train_save_load_predict(self):
+    def test_model_can_train_save_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file, tolerance=1e-2)
+
+    @requires_gpu
+    def test_model_can_train_save_load_with_amp(self):
+        self.ensure_model_can_train_save_and_load(
+            self.param_file,
+            tolerance=1e-2,
+            overrides="{'trainer.use_amp':true, 'trainer.cuda_device':0}",
+        )
 
     def test_vocab(self):
         vocab = self.model.vocab

--- a/tests/generation/models/simple_seq2seq_test.py
+++ b/tests/generation/models/simple_seq2seq_test.py
@@ -3,7 +3,8 @@ import json
 import numpy
 import torch
 
-from allennlp.common.testing import ModelTestCase
+from allennlp.commands.train import train_model_from_file
+from allennlp.common.testing import ModelTestCase, requires_gpu
 from allennlp.nn.beam_search import BeamSearch
 from allennlp.nn.util import sequence_cross_entropy_with_logits
 
@@ -20,6 +21,14 @@ class SimpleSeq2SeqTest(ModelTestCase):
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file, tolerance=1e-2)
+
+    @requires_gpu
+    def test_model_can_train_with_amp(self):
+        train_model_from_file(
+            self.param_file,
+            self.TEST_DIR,
+            overrides="{'trainer.use_amp':true,'trainer.cuda_device':0}",
+        )
 
     def test_bidirectional_model_can_train_save_and_load(self):
         param_overrides = json.dumps({"model": {"encoder": {"bidirectional": True}}})


### PR DESCRIPTION
Fixes models that use an RNN cell by wrapping the forward call to the cell within an `autocast(False)` context.