### PR TITLE
Add test for sentiment analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added regression tests for training configs that run on a scheduled workflow.
+- Added a test for the pretrained sentiment analysis model.
 
 ## [v1.1.0rc3](https://github.com/allenai/allennlp-models/releases/tag/v1.1.0rc3) - 2020-08-12
 

--- a/tests/pretrained_test.py
+++ b/tests/pretrained_test.py
@@ -361,6 +361,11 @@ class TestAllenNlpPretrainedModels(AllenNlpTestCase):
         ]
         assert result["predicted_heads"] == [2, 0, 2, 2, 4, 2]
 
+    def test_sentiment_analysis(self):
+        predictor = load_predictor("roberta-sst")
+        result = predictor.predict_json({"sentence": "This is a positive review."})
+        assert result["label"] == "1"
+
     def test_openie(self):
         predictor = load_predictor("structured-prediction-srl")
         result = predictor.predict_json(


### PR DESCRIPTION
I went to write a test for https://github.com/allenai/allennlp/pull/4576, then discovered that the test passed, and the issue had already been fixed (by #110, apparently, looking at the git blame).  I must have gotten myself into a broken state of mismatched commits between repos when I saw the error.  Oops.  Still useful to have the test, though, I think.