### PR TITLE
always run configs CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,8 +109,7 @@ jobs:
 
   configs:
     name: Training Configs 
-    # Don't run for forks, and only run for master pushes and on schedule.
-    if: github.repository == 'allenai/allennlp-models' && github.event_name != 'pull_request'
+    if: github.repository == 'allenai/allennlp-models'
     runs-on: [self-hosted]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,30 @@ jobs:
       run: |
         make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='gpu-test'
 
+  configs:
+    name: Training Configs 
+    if: github.repository == 'allenai/allennlp-models'
+    runs-on: [self-hosted]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set Docker tag
+      run: |
+        if [[ $GITHUB_EVENT_NAME == 'release' ]]; then
+            echo "::set-env name=DOCKER_TAG::${GITHUB_REF#refs/tags/}";
+        else
+            echo "::set-env name=DOCKER_TAG::$GITHUB_SHA";
+        fi
+
+    - name: Build test image
+      run: |
+        make docker-test-image DOCKER_TAG=$DOCKER_TAG
+
+    - name: Validate training configs
+      run: |
+        make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='test-configs'
+
   # Builds the API documentation and pushes it to the appropriate folder in the
   # allennlp-docs repo.
   docs:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ typecheck :
 
 .PHONY : test
 test :
-	pytest --color=yes -rf --durations=40 -m "not pretrained_model_test" -m "not pretrained_config_test"
+	pytest --color=yes -rf --durations=40 -m "not pretrained_model_test and not pretrained_config_test"
 
 .PHONY : gpu-test
 gpu-test :
@@ -67,8 +67,7 @@ gpu-test :
 .PHONY : test-with-cov
 test-with-cov :
 	pytest --color=yes -rf --durations=40 \
-			-m "not pretrained_model_test" \
-			-m "not pretrained_config_test" \
+			-m "not pretrained_model_test and not pretrained_config_test" \
 			--cov-config=.coveragerc \
 			--cov=allennlp_models/ \
 			--cov-report=xml


### PR DESCRIPTION
Now that we're running the config tests in parallel, they don't take nearly as long, so I think it's worth running them on PRs again.

This also fixes a bug I introduced on one of the last PRs where the pretrained model tests were being run in the "Checks" workflow, which makes that workflow take like 16 minutes 😮 