### PR TITLE
Update BartEncoder docstring for embeddings guidance

### DIFF
--- a/allennlp_models/generation/models/bart.py
+++ b/allennlp_models/generation/models/bart.py
@@ -20,9 +20,11 @@ import torch.nn.functional as F
 @Seq2SeqEncoder.register("bart_encoder")
 class BartEncoder(Seq2SeqEncoder):
     """
-    The BART encoder without the token and position embeddings. This model requires inputs to already be embedded.
-    For a pre-trained encoder model with pre-trained token and position embeddings use
-    `PretrainedTransformerEmbedder(model_name, sub_module="encoder")` with a pretrained BART model.
+    The BART encoder, implemented as a `Seq2SeqEncoder`, which assumes it operates on
+    already embedded inputs.  This means that we remove the token and position embeddings
+    from BART in this module.  For the typical use case of using BART to encode inputs to your
+    model (where we include the token and position embeddings from BART), you should use
+    `PretrainedTransformerEmbedder(bart_model_name, sub_module="encoder")` instead of this.
 
     # Parameters
 

--- a/allennlp_models/generation/models/bart.py
+++ b/allennlp_models/generation/models/bart.py
@@ -97,7 +97,9 @@ class _BartEncoderWrapper(nn.Module):
 
     @overrides
     def forward(
-        self, input_ids, attention_mask=None,
+        self,
+        input_ids,
+        attention_mask=None,
     ):
         x = self.embed_tokens(input_ids) + self.embed_positions(input_ids)
         encoder_states = self.encoder(x, attention_mask)

--- a/allennlp_models/generation/models/bart.py
+++ b/allennlp_models/generation/models/bart.py
@@ -20,7 +20,9 @@ import torch.nn.functional as F
 @Seq2SeqEncoder.register("bart_encoder")
 class BartEncoder(Seq2SeqEncoder):
     """
-    The BART encoder without the token and position embeddings.
+    The BART encoder without the token and position embeddings. This model requires inputs to already be embedded. 
+    For a pre-trained encoder model with pre-trained token and position embeddings use
+    `PretrainedTransformerEmbedder(model_name, sub_module="encoder")` with a pretrained BART model. 
 
     # Parameters
 

--- a/allennlp_models/generation/models/bart.py
+++ b/allennlp_models/generation/models/bart.py
@@ -20,9 +20,9 @@ import torch.nn.functional as F
 @Seq2SeqEncoder.register("bart_encoder")
 class BartEncoder(Seq2SeqEncoder):
     """
-    The BART encoder without the token and position embeddings. This model requires inputs to already be embedded. 
+    The BART encoder without the token and position embeddings. This model requires inputs to already be embedded.
     For a pre-trained encoder model with pre-trained token and position embeddings use
-    `PretrainedTransformerEmbedder(model_name, sub_module="encoder")` with a pretrained BART model. 
+    `PretrainedTransformerEmbedder(model_name, sub_module="encoder")` with a pretrained BART model.
 
     # Parameters
 
@@ -95,9 +95,7 @@ class _BartEncoderWrapper(nn.Module):
 
     @overrides
     def forward(
-        self,
-        input_ids,
-        attention_mask=None,
+        self, input_ids, attention_mask=None,
     ):
         x = self.embed_tokens(input_ids) + self.embed_positions(input_ids)
         encoder_states = self.encoder(x, attention_mask)


### PR DESCRIPTION
Addition to the docstring of `BartEncoder` to point users to a different model if they want the encoder with pretrained token and position embeddings. 

Relevant to an overly complicated [feature request](https://github.com/allenai/allennlp/issues/4604) I made to allow the BartEncoder to use pre-trained embeddings. Instead points user to use `PretrainedTransformerEmbedder` instead of `BartEncoder` so others don't get lost like I did. 