### PR TITLE
add beam search to NextTokenLm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added official support for Python 3.8.
 - Added a json template for model cards.
 - Added `training_config` as a field in model cards.
+- Added a `BeamSearchGenerator` registrable class which can be provided to a `NextTokenLM` model
+  to utilize beam search for predicting a sequence of tokens, instead of a single next token.
+  `BeamSearchGenerator` is an abstract class, so a concrete registered implementation needs to be used.
+  One implementation is provided so far: `TransformerBeamSearchGenerator`, registered as `transformer`,
+  which will work with any `NextTokenLM` that uses a `PretrainedTransformerEmbedder`.
+- Added an `overrides` parameter to `pretrained.load_predictor()`.
 
 ### Changed
 

--- a/allennlp_models/lm/__init__.py
+++ b/allennlp_models/lm/__init__.py
@@ -3,3 +3,4 @@ from allennlp_models.lm.dataset_readers import *
 from allennlp_models.lm.models import *
 from allennlp_models.lm.modules import *
 from allennlp_models.lm.predictors import *
+from allennlp_models.lm.util import *

--- a/allennlp_models/lm/models/next_token_lm.py
+++ b/allennlp_models/lm/models/next_token_lm.py
@@ -82,6 +82,10 @@ class NextTokenLM(Model):
         self._n_best = n_best
         self._beam_search_generator = beam_search_generator
 
+        # Ensure beam_search_generator is compatable with text_field_embedder.
+        if self._beam_search_generator is not None:
+            self._beam_search_generator.validate_text_field_embedder(self._text_field_embedder)
+
         if initializer is not None:
             initializer(self)
 
@@ -125,7 +129,7 @@ class NextTokenLM(Model):
                 target_logits.size()[0], device=target_logits.device, dtype=torch.int
             )
 
-            state = self._beam_search_generator.get_start_state(tokens)
+            state = self._beam_search_generator.get_step_state(tokens)
 
             # Put this in here to avoid having to re-compute on the first step of beam search.
             state["start_target_logits"] = target_logits

--- a/allennlp_models/lm/predictors/next_token_lm.py
+++ b/allennlp_models/lm/predictors/next_token_lm.py
@@ -20,10 +20,7 @@ class NextTokenLMPredictor(Predictor):
     ):
         new_instance = instance.duplicate()
         token_field: TextField = instance["tokens"]  # type: ignore
-        mask_targets = [
-            Token(target_top_k_text[0], text_id=target_top_id_id)
-            for (target_top_k_text, target_top_id_id) in zip(outputs["words"], outputs["token_ids"])
-        ]
+        mask_targets = [Token(target_top_k[0]) for target_top_k in outputs["top_tokens"][0]]
 
         new_instance.add_field(
             "target_ids",

--- a/allennlp_models/lm/util/__init__.py
+++ b/allennlp_models/lm/util/__init__.py
@@ -1,0 +1,1 @@
+from .beam_search_generators import *  # noqa: F403

--- a/allennlp_models/lm/util/beam_search_generators/__init__.py
+++ b/allennlp_models/lm/util/beam_search_generators/__init__.py
@@ -1,0 +1,2 @@
+from .beam_search_generator import BeamSearchGenerator
+from .transformer_beam_search_generator import TransformerBeamSearchGenerator

--- a/allennlp_models/lm/util/beam_search_generators/beam_search_generator.py
+++ b/allennlp_models/lm/util/beam_search_generators/beam_search_generator.py
@@ -1,0 +1,51 @@
+from typing import Dict, Tuple
+
+import torch
+
+from allennlp.common.registrable import Registrable
+from allennlp.data import TextFieldTensors
+from allennlp.nn.beam_search import BeamSearch, StepFunctionType
+
+
+class BeamSearchGenerator(Registrable):
+    """
+    A beam search generator for next token language models.
+
+    This is just a wrapper around `allennlp.nn.beam_search.BeamSearch` with custom
+    logic for handling the `state` dict.
+    """
+
+    def __init__(self, beam_search: BeamSearch):
+        self._beam_search = beam_search
+
+    def get_start_state(self, tokens: TextFieldTensors) -> Dict[str, torch.Tensor]:
+        """
+        Get an initial state dictionary from the `tokens` input to the forward
+        pass of a `NextTokenLm` model.
+        """
+        raise NotImplementedError
+
+    def get_step_state(self, inputs: TextFieldTensors) -> Dict[str, torch.Tensor]:
+        raise NotImplementedError
+
+    def prepare_step_input(
+        self, predictions: torch.Tensor, state: Dict[str, torch.Tensor]
+    ) -> TextFieldTensors:
+        raise NotImplementedError
+
+    def search(
+        self,
+        start_predictions: torch.Tensor,
+        state: Dict[str, torch.Tensor],
+        step_function: StepFunctionType,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Calls `BeamSearch.search`, return the top predicted indices and corresponding
+        log probabilities.
+        """
+        # Shape (top_indices): (batch_size, beam_size, num_predicted_tokens)
+        # Shape (top_log_probs): (batch_size, beam_size)
+        top_indices, top_log_probs = self._beam_search.search(
+            start_predictions, state, step_function
+        )
+        return top_indices, top_log_probs

--- a/allennlp_models/lm/util/beam_search_generators/beam_search_generator.py
+++ b/allennlp_models/lm/util/beam_search_generators/beam_search_generator.py
@@ -4,6 +4,7 @@ import torch
 
 from allennlp.common.registrable import Registrable
 from allennlp.data import TextFieldTensors
+from allennlp.modules import TextFieldEmbedder
 from allennlp.nn.beam_search import BeamSearch, StepFunctionType
 
 
@@ -13,24 +14,63 @@ class BeamSearchGenerator(Registrable):
 
     This is just a wrapper around `allennlp.nn.beam_search.BeamSearch` with custom
     logic for handling the `state` dict.
+
+    The reason we need this is because the step function that `BeamSearch` uses
+    needs to know how to handle different `TextFieldTensors`, the form of which
+    depends on the exact embedder class that the `NextTokenLm` uses.
+
+    So essentially we need a different `BeamSearchGenerator` implementation
+    for each different `text_field_embedder`.
     """
 
     def __init__(self, beam_search: BeamSearch):
         self._beam_search = beam_search
 
-    def get_start_state(self, tokens: TextFieldTensors) -> Dict[str, torch.Tensor]:
+    def validate_text_field_embedder(self, text_field_embedder: TextFieldEmbedder):
         """
-        Get an initial state dictionary from the `tokens` input to the forward
-        pass of a `NextTokenLm` model.
+        This should be called after initialization to verify that the model's
+        `text_field_embedder` is compatable.
         """
         raise NotImplementedError
 
     def get_step_state(self, inputs: TextFieldTensors) -> Dict[str, torch.Tensor]:
-        raise NotImplementedError
+        """
+        Create a `state` dictionary for `BeamSearch` from the `TextFieldTensors` inputs
+        to the `NextTokenLm` model.
+
+        By default this assumes the `TextFieldTensors` has a single `TokenEmbedder`,
+        and just "flattens" the `TextFieldTensors` by returning the `TokenEmbedder`
+        sub-dictionary.
+
+        If you have `TextFieldTensors` with more than one `TokenEmbedder` sub-dictionary,
+        you'll need to override this class.
+        """
+        assert len(inputs) == 1, (
+            "'get_step_state()' assumes a single token embedder by default, "
+            "you'll need to override this method to handle more than one"
+        )
+
+        key = list(inputs.keys())[0]
+
+        # We can't just `return inputs[key]` because we might want to modify the state
+        # dictionary (add or remove fields) without accidentally modifying the inputs
+        # dictionary.
+        return {k: v for (k, v) in inputs[key].items()}
 
     def prepare_step_input(
         self, predictions: torch.Tensor, state: Dict[str, torch.Tensor]
     ) -> TextFieldTensors:
+        """
+        This is like the reverse of `get_step_state()`.
+
+        It takes `predictions` and `state` from the current step and returns
+        a `TextFieldTensors` dictionary that can be fed through the embedder of the `NextTokenLm`
+        model.
+
+        This usually involves adding the predicted tokens to the proper field of the `state` dict,
+        and expanding any mask tensors or other context tensors by 1 in the right dimension,
+        and then unflattening the `state` so that it looks like a `TextFieldTensors` dict.
+        """
         raise NotImplementedError
 
     def search(

--- a/allennlp_models/lm/util/beam_search_generators/transformer_beam_search_generator.py
+++ b/allennlp_models/lm/util/beam_search_generators/transformer_beam_search_generator.py
@@ -1,10 +1,11 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from overrides import overrides
 import torch
 
 from allennlp.data import TextFieldTensors
-from allennlp.nn.beam_search import BeamSearch
+from allennlp.modules.text_field_embedders import TextFieldEmbedder, BasicTextFieldEmbedder
+from allennlp.modules.token_embedders import PretrainedTransformerEmbedder
 from .beam_search_generator import BeamSearchGenerator
 
 
@@ -12,22 +13,22 @@ from .beam_search_generator import BeamSearchGenerator
 class TransformerBeamSearchGenerator(BeamSearchGenerator):
     """
     A `BeamSearchGenerator` for transformer-based `NextTokenLM` models.
+
+    This can be used with any `NextTokenLM` that utilizes a single `pretrained_transformer`
+    `TokenEmbedder` for it's `text_field_embedder`.
     """
 
-    def __init__(self, namespace: str, beam_search: BeamSearch) -> None:
-        super().__init__(beam_search)
-        self._namespace = namespace
+    def __init__(self, *args, namespace: str = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._namespace: Optional[str] = namespace
 
     @overrides
-    def get_start_state(
-        self,
-        tokens: TextFieldTensors,
-    ) -> Dict[str, torch.Tensor]:
-        return {k: v for (k, v) in tokens[self._namespace].items()}
-
-    @overrides
-    def get_step_state(self, inputs: TextFieldTensors) -> Dict[str, torch.Tensor]:
-        return inputs[self._namespace]
+    def validate_text_field_embedder(self, text_field_embedder: TextFieldEmbedder):
+        assert isinstance(text_field_embedder, BasicTextFieldEmbedder)
+        assert len(text_field_embedder._token_embedders) == 1
+        key = list(text_field_embedder._token_embedders.keys())[0]
+        assert isinstance(text_field_embedder._token_embedders[key], PretrainedTransformerEmbedder)
+        self._namespace = key
 
     @overrides
     def prepare_step_input(
@@ -79,6 +80,12 @@ class TransformerBeamSearchGenerator(BeamSearchGenerator):
         # Shape: (group_size, num_tokens + 1)
         state["type_ids"] = torch.cat([type_ids, type_ids[:, -1].unsqueeze(-1)], dim=-1)
 
+        # The model expect input in the form of TextFieldTensors, which just has another
+        # nested layer like this:
+        assert self._namespace is not None, (
+            "token embedder namespace could not be inferred, "
+            "did you forget to call 'validate_text_field_embedder()'?"
+        )
         inputs = {self._namespace: state}
 
         return inputs

--- a/allennlp_models/lm/util/beam_search_generators/transformer_beam_search_generator.py
+++ b/allennlp_models/lm/util/beam_search_generators/transformer_beam_search_generator.py
@@ -1,0 +1,84 @@
+from typing import Dict, List
+
+from overrides import overrides
+import torch
+
+from allennlp.data import TextFieldTensors
+from allennlp.nn.beam_search import BeamSearch
+from .beam_search_generator import BeamSearchGenerator
+
+
+@BeamSearchGenerator.register("transformer")
+class TransformerBeamSearchGenerator(BeamSearchGenerator):
+    """
+    A `BeamSearchGenerator` for transformer-based `NextTokenLM` models.
+    """
+
+    def __init__(self, namespace: str, beam_search: BeamSearch) -> None:
+        super().__init__(beam_search)
+        self._namespace = namespace
+
+    @overrides
+    def get_start_state(
+        self,
+        tokens: TextFieldTensors,
+    ) -> Dict[str, torch.Tensor]:
+        return {k: v for (k, v) in tokens[self._namespace].items()}
+
+    @overrides
+    def get_step_state(self, inputs: TextFieldTensors) -> Dict[str, torch.Tensor]:
+        return inputs[self._namespace]
+
+    @overrides
+    def prepare_step_input(
+        self, predictions: torch.Tensor, state: Dict[str, torch.Tensor]
+    ) -> TextFieldTensors:
+        # Add `predicted_tokens` to `state["token_ids"]` and expand `state["mask"]`.
+        new_token_ids: List[torch.Tensor] = []
+        new_mask: List[torch.Tensor] = []
+        for instance_token_ids, instance_mask, prediction in zip(
+            state["token_ids"], state["mask"], predictions
+        ):
+            # Shape: (?,)
+            masked_out = (instance_mask == False).nonzero(as_tuple=False).squeeze(-1)  # noqa: E712
+            if masked_out.size()[0] > 0:
+                first_mask_index = masked_out[0].item()
+            else:
+                first_mask_index = instance_token_ids.size()[0]
+
+            # Shape: (batch_size, num_tokens + 1)
+            new_instance_token_ids = torch.cat(
+                [
+                    instance_token_ids[0:first_mask_index],
+                    prediction.unsqueeze(0),
+                    instance_token_ids[first_mask_index:],
+                ],
+                dim=-1,
+            )
+
+            # Shape: (batch_size, num_tokens + 1)
+            new_instance_mask = torch.cat(
+                [
+                    instance_mask[0:first_mask_index],
+                    torch.tensor([True], device=instance_mask.device),
+                    instance_mask[first_mask_index:],
+                ],
+                dim=-1,
+            )
+
+            new_token_ids.append(new_instance_token_ids)
+            new_mask.append(new_instance_mask)
+
+        state["token_ids"] = torch.stack(new_token_ids, 0)
+        state["mask"] = torch.stack(new_mask, 0)
+
+        # Expand `state["type_ids"]` by 1 in the last dimension, just repeating whatever the last
+        # value is.
+        # Shape: (group_size, num_tokens)
+        type_ids = state.pop("type_ids")
+        # Shape: (group_size, num_tokens + 1)
+        state["type_ids"] = torch.cat([type_ids, type_ids[:, -1].unsqueeze(-1)], dim=-1)
+
+        inputs = {self._namespace: state}
+
+        return inputs

--- a/allennlp_models/pretrained.py
+++ b/allennlp_models/pretrained.py
@@ -1,6 +1,6 @@
 import os
 import glob
-from typing import Dict
+from typing import Dict, Union, Any
 
 from allennlp.common import Params
 from allennlp.predictors import Predictor
@@ -38,7 +38,11 @@ def get_pretrained_models() -> Dict[str, ModelCard]:
     return pretrained_models
 
 
-def load_predictor(model_id: str, pretrained_models: Dict[str, ModelCard] = None) -> Predictor:
+def load_predictor(
+    model_id: str,
+    pretrained_models: Dict[str, ModelCard] = None,
+    overrides: Union[str, Dict[str, Any]] = None,
+) -> Predictor:
     """
     Returns the `Predictor` corresponding to the given `model_id`.
 
@@ -50,5 +54,7 @@ def load_predictor(model_id: str, pretrained_models: Dict[str, ModelCard] = None
     if model_card.archive_file is None:
         raise ValueError(f"archive_file is required in the {model_card}")
     return Predictor.from_path(
-        model_card.archive_file, predictor_name=model_card.registered_predictor_name
+        model_card.archive_file,
+        predictor_name=model_card.registered_predictor_name,
+        overrides=overrides,
     )

--- a/test_fixtures/lm/next_token_lm/experiment_transformer.json
+++ b/test_fixtures/lm/next_token_lm/experiment_transformer.json
@@ -31,7 +31,6 @@
     },
     "beam_search_generator": {
       "type": "transformer",
-      "namespace": "tokens",
       "beam_search": {
         "end_index": 3,
         "beam_size": 2,

--- a/test_fixtures/lm/next_token_lm/experiment_transformer.json
+++ b/test_fixtures/lm/next_token_lm/experiment_transformer.json
@@ -1,0 +1,53 @@
+{
+  "dataset_reader": {
+    "type": "next_token_lm",
+    "tokenizer": {
+      "type": "pretrained_transformer",
+      "model_name": "test_fixtures/bert-xsmall-dummy"
+    },
+    "token_indexers": {
+      "tokens": {
+        "type": "pretrained_transformer",
+        "model_name": "test_fixtures/bert-xsmall-dummy"
+      }
+    }
+  },
+  "train_data_path": "test_fixtures/lm/language_model/sentences.txt",
+  "validation_data_path": "test_fixtures/lm/language_model/sentences.txt",
+  "model": {
+    "type": "next_token_lm",
+    "target_namespace": "tokens",
+    "text_field_embedder": {
+      "token_embedders": {
+        "tokens": {
+          "type": "pretrained_transformer",
+          "model_name": "test_fixtures/bert-xsmall-dummy"
+        }
+      }
+    },
+    "language_model_head": {
+      "type": "bert",
+      "model_name": "test_fixtures/bert-xsmall-dummy"
+    },
+    "beam_search_generator": {
+      "type": "transformer",
+      "namespace": "tokens",
+      "beam_search": {
+        "end_index": 3,
+        "beam_size": 2,
+        "max_steps": 5,
+      }
+    }
+  },
+  "data_loader": {
+    "batch_size": 32
+  },
+  "trainer": {
+    "num_epochs": 1,
+    "cuda_device" : -1,
+    "optimizer": {
+      "type": "sgd",
+      "lr": 0.01
+    }
+  }
+}

--- a/tests/lm/models/next_token_lm_test.py
+++ b/tests/lm/models/next_token_lm_test.py
@@ -1,6 +1,7 @@
 from allennlp.common.testing import ModelTestCase
 
 from tests import FIXTURES_ROOT
+from allennlp_models import lm  # noqa: F401
 
 
 class TestNextTokenLanguageModel(ModelTestCase):
@@ -13,3 +14,22 @@ class TestNextTokenLanguageModel(ModelTestCase):
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
+
+
+class TestNextTokenTransformerLm(ModelTestCase):
+    def setup_method(self):
+        super().setup_method()
+        self.set_up_model(
+            FIXTURES_ROOT / "lm" / "next_token_lm" / "experiment_transformer.json",
+            FIXTURES_ROOT / "lm" / "language_model" / "sentences.txt",
+        )
+
+    def test_model_can_train_save_and_load(self):
+        self.ensure_model_can_train_save_and_load(
+            self.param_file,
+            tolerance=1e-3,
+            gradients_to_ignore={
+                "_text_field_embedder.token_embedder_tokens.transformer_model.pooler.dense.weight",
+                "_text_field_embedder.token_embedder_tokens.transformer_model.pooler.dense.bias",
+            },
+        )

--- a/tests/lm/predictors/next_token_lm_test.py
+++ b/tests/lm/predictors/next_token_lm_test.py
@@ -3,6 +3,7 @@ from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
 
 from tests import FIXTURES_ROOT
+from allennlp_models import lm  # noqa: F401
 
 
 class TestNextTokenLMPredictor(AllenNlpTestCase):


### PR DESCRIPTION
Example usage:

```python
from allennlp_models.pretrained import load_predictor

predictor = load_predictor(
    "lm-next-token-lm-gpt2",
    overrides={
        "model.beam_search_generator": {
            "type": "transformer",
            "namespace": "gpt2",
            "beam_search": {
                "end_index": 50256,
                "max_steps": 5,
                "beam_size": 5,
            },
        }
    },
)
print(predictor.predict("AllenNLP is")["top_tokens"])

#> [['Ġan', 'Ġindependent', ',', 'Ġnon', '-'], ['Ġone', 'Ġof', 'Ġthe', 'Ġmost', 'Ġpopular'], ['Ġa', 'Ġmember', 'Ġof', 'Ġthe', 'ĠNational'], ['Ġa', 'Ġmember', 'Ġof', 'Ġthe', 'ĠAmerican'], ['Ġa', 'Ġmember', 'Ġof', 'Ġthe', 'ĠAustralian']]
```

Still TODO:
- [x] Update the demo UI in `src/components/demos/LanguageModel.js`.
- [x] Update the demo LM endpoint to load the predictor with beam search enable just like in the example above.

The output from the predictor has changed slightly. It used to look like this:

<details><summary>Show details 👇</summary></br>

```json
{
    "probabilities": [
        0.21509116888046265,
        0.057026106864213943,
        0.052574608474969864,
        0.040182922035455704,
        0.01481600385159254
    ],
    "top_indices": [
        257,
        262,
        281,
        407,
        530
    ],
    "token_ids": [
        39989,
        45,
        19930,
        318
    ],
    "words": [
        [
            "\u0120a",
            "\u0120the",
            "\u0120an",
            "\u0120not",
            "\u0120one"
        ]
    ],
    "tokens": [
        "Allen",
        "N",
        "LP",
        "\u0120is"
    ]
}
```

</details>

Now it looks like this:

<details><summary>Show details 👇</summary></br>

```json
{
    "token_ids": [
        39989,
        45,
        19930,
        318
    ],
    "top_indices": [
        [
            281,
            4795,
            11,
            1729,
            12
        ],
        [
            530,
            286,
            262,
            749,
            2968
        ],
        [
            257,
            2888,
            286,
            262,
            2351
        ],
        [
            257,
            2888,
            286,
            262,
            1605
        ],
        [
            257,
            2888,
            286,
            262,
            6638
        ]
    ],
    "probabilities": [
        0.00023289884848054498,
        0.00015596384764648974,
        0.0001039400085574016,
        5.8540405007079244e-05,
        5.512762800208293e-05
    ],
    "top_tokens": [
        [
            "\u0120an",
            "\u0120independent",
            ",",
            "\u0120non",
            "-"
        ],
        [
            "\u0120one",
            "\u0120of",
            "\u0120the",
            "\u0120most",
            "\u0120popular"
        ],
        [
            "\u0120a",
            "\u0120member",
            "\u0120of",
            "\u0120the",
            "\u0120National"
        ],
        [
            "\u0120a",
            "\u0120member",
            "\u0120of",
            "\u0120the",
            "\u0120American"
        ],
        [
            "\u0120a",
            "\u0120member",
            "\u0120of",
            "\u0120the",
            "\u0120Australian"
        ]
    ],
    "tokens": [
        "Allen",
        "N",
        "LP",
        "\u0120is"
    ]
}
```

</details>