### PR TITLE
allow for range of AllenNLP versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,7 @@ jobs:
 
     - name: Set AllenNLP version override
       run: |
-        VERSION=$(./scripts/get_version.py current --minimal)
-        ALLENNLP_VERSION_OVERRIDE="allennlp==$VERSION"
+        ALLENNLP_VERSION_OVERRIDE="allennlp$(./scripts/get_version.py current --as-range)"
         echo "Setting ALLENNLP_VERSION_OVERRIDE to $ALLENNLP_VERSION_OVERRIDE"
         echo "ALLENNLP_VERSION_OVERRIDE=$ALLENNLP_VERSION_OVERRIDE" >> $GITHUB_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Changed AllenNLP dependency for releases to allow for a range of versions, instead
+  of being pinned to an exact version.
+
 
 ## [v1.2.1](https://github.com/allenai/allennlp-models/releases/tag/v1.2.1) - 2020-11-10
 

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -8,12 +8,17 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("version_type", choices=["stable", "latest", "current"])
     parser.add_argument("--minimal", action="store_true", default=False)
+    parser.add_argument("--as-range", action="store_true", default=False)
     return parser.parse_args()
 
 
-def post_process(version: str, minimal: bool = False):
+def post_process(version: str, minimal: bool = False, as_range: bool = False):
+    assert not (minimal and as_range)
     if version.startswith("v"):
-        return version if not minimal else version[1:]
+        version = version[1:]
+    if as_range:
+        major, minor, *_ = version.split(".")
+        return f">={version},<{major}.{int(minor)+1}"
     return version if minimal else f"v{version}"
 
 
@@ -43,11 +48,11 @@ def get_stable_version() -> str:
 def main() -> None:
     opts = parse_args()
     if opts.version_type == "stable":
-        print(post_process(get_stable_version(), opts.minimal))
+        print(post_process(get_stable_version(), opts.minimal, opts.as_range))
     elif opts.version_type == "latest":
-        print(post_process(get_latest_version(), opts.minimal))
+        print(post_process(get_latest_version(), opts.minimal, opts.as_range))
     elif opts.version_type == "current":
-        print(post_process(get_current_version(), opts.minimal))
+        print(post_process(get_current_version(), opts.minimal, opts.as_range))
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
So I got to thinking that the core library tends to have a lot more activity than the models repo, and therefore it's likely that we'd want to do patch releases in the core library without bothering to do a corresponding patch release of models.

But we can't do that right now since every models release is pinned to the exact patch version of AllenNLP. For example, if we wanted to release AllenNLP 1.2.2 without doing a models release of 1.2.2, someone with models version 1.2.1 installed would have a dependency conflict if they tried to upgrade the core library to 1.2.2.

This PR proposes that we slightly decouple models from core, by allowing for a range of versions of the core library. In particular, if models is at 1.2.1, its core dependency would be `allennlp>=1.2.1,<1.3` instead of `allennlpl==1.2.1`. So this forces us to do a corresponding modes releases for every major or minor core release, but not for core patch releases.