### PR TITLE
Fix bad start or end symbol error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `pair-classification-esim` pretrained model.
+- Fixed `ValueError` error message in `Seq2SeqDatasetReader`.
 
 ### Added
 

--- a/allennlp_models/generation/dataset_readers/seq2seq.py
+++ b/allennlp_models/generation/dataset_readers/seq2seq.py
@@ -97,7 +97,7 @@ class Seq2SeqDatasetReader(DatasetReader):
                 )
             except ValueError:
                 raise ValueError(
-                    f"Bad start or end symbol ({'start_symbol', 'end_symbol'}) "
+                    f"Bad start or end symbol ('{start_symbol}', '{end_symbol}') "
                     f"for tokenizer {self._source_tokenizer}"
                 )
 

--- a/tests/generation/dataset_readers/seq2seq_test.py
+++ b/tests/generation/dataset_readers/seq2seq_test.py
@@ -218,5 +218,5 @@ class TestSeq2SeqDatasetReader:
             ]
 
     def test_bad_start_or_end_symbol(self):
-        with pytest.raises(ValueError, match="Bad start or end symbol \('BAD SYMBOL"):
+        with pytest.raises(ValueError, match=r"Bad start or end symbol \('BAD SYMBOL"):
             Seq2SeqDatasetReader(start_symbol="BAD SYMBOL")

--- a/tests/generation/dataset_readers/seq2seq_test.py
+++ b/tests/generation/dataset_readers/seq2seq_test.py
@@ -218,5 +218,5 @@ class TestSeq2SeqDatasetReader:
             ]
 
     def test_bad_start_or_end_symbol(self):
-        with pytest.raises(ValueError, match="Bad start or end symbol"):
+        with pytest.raises(ValueError, match="Bad start or end symbol \('BAD SYMBOL"):
             Seq2SeqDatasetReader(start_symbol="BAD SYMBOL")


### PR DESCRIPTION
This is a small PR that fixes what _I think_ was a typo in the error message of a `ValueError` thrown by `Seq2SeqDatasetReader`. Instead of printing out the "bad" `start_symbol` and `end_symbol`, it was printing the literal strings `"start_symbol"` and `"end_symbol"`. This wasn't caught by the unit tests, so I also updated the relevant test to catch it.

I ran into this because I actually triggered the error, and realized it wasn't reporting to me the "bad" symbols I was using.