### PR TITLE
Fix an index bug in  BART prediction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix an index bug in  BART prediction.
+
 ### Added
 
 - Added link to source code to API docs.

--- a/allennlp_models/generation/models/bart.py
+++ b/allennlp_models/generation/models/bart.py
@@ -390,7 +390,7 @@ class Bart(Model):
         predicted_tokens = [None] * predictions.shape[0]
         for i in range(predictions.shape[0]):
             predicted_tokens[i] = self._indexer.indices_to_tokens(
-                {"token_ids": predictions[0].tolist()}, self.vocab
+                {"token_ids": predictions[i].tolist()}, self.vocab
             )
         output_dict["predicted_tokens"] = predicted_tokens
 


### PR DESCRIPTION
The index should be `i` rather than `0` in `make_output_human_readable` method.