### PR TITLE
Introduce `convert_to_coding_scheme` and make `coding_scheme` deprecated in `Conll2002DatasetReader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 'master' branch renamed to 'main'
 - `SquadEmAndF1` metric can now also accept a batch of predictions and corresponding answers (instead of a single one)
   in the form of list (for each).
+- Introduce `convert_to_coding_scheme` and make `coding_scheme` deprecated in `Conll2002DatasetReader`.
 
 ### Fixed
 
@@ -31,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix an index bug in  BART prediction.
-- Add `None` check in `PrecoReader`'s `text_to_instance()` method. 
+- Add `None` check in `PrecoReader`'s `text_to_instance()` method.
 - Fixed `SemanticRoleLabelerPredictor.tokens_to_instances` so it treats auxiliary verbs as verbs
   when the language is English
 
@@ -67,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `short_description` field to `ModelCard`. 
+- Added `short_description` field to `ModelCard`.
 - Information updates for all model cards.
 
 

--- a/allennlp_models/tagging/dataset_readers/conll2000.py
+++ b/allennlp_models/tagging/dataset_readers/conll2000.py
@@ -94,7 +94,8 @@ class Conll2000DatasetReader(DatasetReader):
             raise ConfigurationError("unknown coding_scheme: {}".format(convert_to_coding_scheme))
         if convert_to_coding_scheme is None:
             warnings.warn(
-                "`coding_scheme` is deprecated. Consider using `convert_to_coding_scheme`."
+                "`coding_scheme` is deprecated. Consider using `convert_to_coding_scheme`.",
+                DeprecationWarning,
             )
             convert_to_coding_scheme = coding_scheme
 

--- a/allennlp_models/tagging/dataset_readers/conll2000.py
+++ b/allennlp_models/tagging/dataset_readers/conll2000.py
@@ -93,7 +93,9 @@ class Conll2000DatasetReader(DatasetReader):
         if convert_to_coding_scheme not in (None, "BIOUL") or coding_scheme not in ("BIO", "BIOUL"):
             raise ConfigurationError("unknown coding_scheme: {}".format(convert_to_coding_scheme))
         if convert_to_coding_scheme is None:
-            warnings.warn("`coding_scheme` is deprecated. Consider using `convert_to_coding_scheme`.")
+            warnings.warn(
+                "`coding_scheme` is deprecated. Consider using `convert_to_coding_scheme`."
+            )
             convert_to_coding_scheme = coding_scheme
 
         self.tag_label = tag_label

--- a/allennlp_models/tagging/dataset_readers/conll2000.py
+++ b/allennlp_models/tagging/dataset_readers/conll2000.py
@@ -1,6 +1,7 @@
-from typing import Dict, List, Sequence, Iterable
+from typing import Dict, List, Optional, Sequence, Iterable
 import itertools
 import logging
+import warnings
 
 from overrides import overrides
 
@@ -52,12 +53,19 @@ class Conll2000DatasetReader(DatasetReader):
         Each will have its own namespace : `pos_tags` or `chunk_tags`.
         If you want to use one of the tags as a `feature` in your model, it should be
         specified here.
-    coding_scheme : `str`, optional (default=`BIO`)
-        Specifies the coding scheme for `chunk_labels`.
-        Valid options are `BIO` and `BIOUL`.  The `BIO` default maintains
-        the original BIO scheme in the CoNLL 2000 chunking data.
-        In the BIO scheme, B is a token starting a span, I is a token continuing a span, and
-        O is a token outside of a span.
+    convert_to_coding_scheme : `str`, optional (default=`None`)
+        Specifies the coding scheme for `ner_labels` and `chunk_labels`.
+        Valid options are `IOB1` and `BIOUL`.  The `IOB1` default maintains
+        Valid options is `BIOUL`.  If `None`, it default maintains
+        the original IOB1 scheme in the CoNLL 2003 NER data.
+        In the IOB1 scheme, I is a token inside a span, O is a token outside
+        a span and B is the beginning of span immediately following another
+        span of the same type.
+    coding_scheme : `str`, optional (default=`IOB1`)
+        This parameter is deprecated. If you specify `coding_scheme` to
+        `IOB1`, consider simply removing it or specifying `convert_to_coding_scheme`
+        to `None`. If you want to specify `BIOUL` for `coding_scheme`,
+        consider replacing it with `convert_to_coding_scheme`.
     label_namespace : `str`, optional (default=`labels`)
         Specifies the namespace for the chosen `tag_label`.
     """
@@ -71,6 +79,8 @@ class Conll2000DatasetReader(DatasetReader):
         feature_labels: Sequence[str] = (),
         coding_scheme: str = "BIO",
         label_namespace: str = "labels",
+        *,
+        convert_to_coding_scheme: Optional[str] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -80,12 +90,15 @@ class Conll2000DatasetReader(DatasetReader):
         for label in feature_labels:
             if label not in self._VALID_LABELS:
                 raise ConfigurationError("unknown feature label type: {}".format(label))
-        if coding_scheme not in ("BIO", "BIOUL"):
-            raise ConfigurationError("unknown coding_scheme: {}".format(coding_scheme))
+        if convert_to_coding_scheme not in (None, "BIOUL") or coding_scheme not in ("BIO", "BIOUL"):
+            raise ConfigurationError("unknown coding_scheme: {}".format(convert_to_coding_scheme))
+        if convert_to_coding_scheme is None:
+            warnings.warn("`coding_scheme` is deprecated. Consider using `convert_to_coding_scheme`.")
+            convert_to_coding_scheme = coding_scheme
 
         self.tag_label = tag_label
         self.feature_labels = set(feature_labels)
-        self.coding_scheme = coding_scheme
+        self.convert_to_coding_scheme = convert_to_coding_scheme
         self.label_namespace = label_namespace
         self._original_coding_scheme = "BIO"
 
@@ -123,7 +136,7 @@ class Conll2000DatasetReader(DatasetReader):
         instance_fields["metadata"] = MetadataField({"words": [x.text for x in tokens]})
 
         # Recode the labels if necessary.
-        if self.coding_scheme == "BIOUL":
+        if self.convert_to_coding_scheme == "BIOUL":
             coded_chunks = (
                 to_bioul(chunk_tags, encoding=self._original_coding_scheme)
                 if chunk_tags is not None

--- a/test_fixtures/tagging/crf_tagger/experiment_conll2000.json
+++ b/test_fixtures/tagging/crf_tagger/experiment_conll2000.json
@@ -1,6 +1,7 @@
 {
   "dataset_reader": {
     "type": "conll2000",
+    "convert_to_coding_scheme": "BIOUL",
     "tag_label": "chunk",
     // Tests that CrfTagger.forward() works when it's passed a
     // keyword argument it doesn't expect

--- a/tests/tagging/dataset_readers/conll2000_test.py
+++ b/tests/tagging/dataset_readers/conll2000_test.py
@@ -236,7 +236,9 @@ class TestConll2000Reader:
     @pytest.mark.parametrize("lazy", (True, False))
     @pytest.mark.parametrize("convert_to_coding_scheme", (None, "BIOUL"))
     def test_read_from_file(self, lazy, convert_to_coding_scheme):
-        conll_reader = Conll2000DatasetReader(lazy=lazy, convert_to_coding_scheme=convert_to_coding_scheme)
+        conll_reader = Conll2000DatasetReader(
+            lazy=lazy, convert_to_coding_scheme=convert_to_coding_scheme
+        )
         instances = conll_reader.read(str(FIXTURES_ROOT / "tagging" / "conll2000.txt"))
         instances = ensure_list(instances)
         assert len(instances) == 2

--- a/tests/tagging/dataset_readers/conll2000_test.py
+++ b/tests/tagging/dataset_readers/conll2000_test.py
@@ -9,7 +9,7 @@ from tests import FIXTURES_ROOT
 class TestConll2000Reader:
     @pytest.mark.parametrize("lazy", (True, False))
     @pytest.mark.parametrize("coding_scheme", ("BIO", "BIOUL"))
-    def test_read_from_file(self, lazy, coding_scheme):
+    def test_read_from_file_with_deprecated_parameter(self, lazy, coding_scheme):
         conll_reader = Conll2000DatasetReader(lazy=lazy, coding_scheme=coding_scheme)
         instances = conll_reader.read(str(FIXTURES_ROOT / "tagging" / "conll2000.txt"))
         instances = ensure_list(instances)
@@ -140,6 +140,232 @@ class TestConll2000Reader:
         assert fields["tags"].labels == expected_labels
 
         if coding_scheme == "BIO":
+            expected_labels = [
+                "O",
+                "B-PP",
+                "B-NP",
+                "I-NP",
+                "B-NP",
+                "I-NP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "B-PP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "I-NP",
+                "B-VP",
+                "I-VP",
+                "I-VP",
+                "I-VP",
+                "B-NP",
+                "I-NP",
+                "B-PP",
+                "B-NP",
+                "B-PP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "O",
+            ]
+        else:
+            expected_labels = [
+                "O",
+                "U-PP",
+                "B-NP",
+                "L-NP",
+                "B-NP",
+                "L-NP",
+                "B-NP",
+                "I-NP",
+                "L-NP",
+                "U-PP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "L-NP",
+                "B-VP",
+                "I-VP",
+                "I-VP",
+                "L-VP",
+                "B-NP",
+                "L-NP",
+                "U-PP",
+                "U-NP",
+                "U-PP",
+                "B-NP",
+                "I-NP",
+                "L-NP",
+                "O",
+            ]
+
+        fields = instances[1].fields
+        tokens = [t.text for t in fields["tokens"].tokens]
+        assert tokens == [
+            "Chancellor",
+            "of",
+            "the",
+            "Exchequer",
+            "Nigel",
+            "Lawson",
+            "'s",
+            "restated",
+            "commitment",
+            "to",
+            "a",
+            "firm",
+            "monetary",
+            "policy",
+            "has",
+            "helped",
+            "to",
+            "prevent",
+            "a",
+            "freefall",
+            "in",
+            "sterling",
+            "over",
+            "the",
+            "past",
+            "week",
+            ".",
+        ]
+        assert fields["tags"].labels == expected_labels
+
+    @pytest.mark.parametrize("lazy", (True, False))
+    @pytest.mark.parametrize("convert_to_coding_scheme", (None, "BIOUL"))
+    def test_read_from_file(self, lazy, convert_to_coding_scheme):
+        conll_reader = Conll2000DatasetReader(lazy=lazy, convert_to_coding_scheme=convert_to_coding_scheme)
+        instances = conll_reader.read(str(FIXTURES_ROOT / "tagging" / "conll2000.txt"))
+        instances = ensure_list(instances)
+        assert len(instances) == 2
+
+        if convert_to_coding_scheme is None:
+            expected_labels = [
+                "B-NP",
+                "B-PP",
+                "B-NP",
+                "I-NP",
+                "B-VP",
+                "I-VP",
+                "I-VP",
+                "I-VP",
+                "I-VP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "B-SBAR",
+                "B-NP",
+                "I-NP",
+                "B-PP",
+                "B-NP",
+                "O",
+                "B-ADJP",
+                "B-PP",
+                "B-NP",
+                "B-NP",
+                "O",
+                "B-VP",
+                "I-VP",
+                "I-VP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "B-PP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "B-NP",
+                "I-NP",
+                "I-NP",
+                "O",
+            ]
+        else:
+            expected_labels = [
+                "U-NP",
+                "U-PP",
+                "B-NP",
+                "L-NP",
+                "B-VP",
+                "I-VP",
+                "I-VP",
+                "I-VP",
+                "L-VP",
+                "B-NP",
+                "I-NP",
+                "L-NP",
+                "U-SBAR",
+                "B-NP",
+                "L-NP",
+                "U-PP",
+                "U-NP",
+                "O",
+                "U-ADJP",
+                "U-PP",
+                "U-NP",
+                "U-NP",
+                "O",
+                "B-VP",
+                "I-VP",
+                "L-VP",
+                "B-NP",
+                "I-NP",
+                "L-NP",
+                "U-PP",
+                "B-NP",
+                "I-NP",
+                "L-NP",
+                "B-NP",
+                "I-NP",
+                "L-NP",
+                "O",
+            ]
+
+        fields = instances[0].fields
+        tokens = [t.text for t in fields["tokens"].tokens]
+        assert tokens == [
+            "Confidence",
+            "in",
+            "the",
+            "pound",
+            "is",
+            "widely",
+            "expected",
+            "to",
+            "take",
+            "another",
+            "sharp",
+            "dive",
+            "if",
+            "trade",
+            "figures",
+            "for",
+            "September",
+            ",",
+            "due",
+            "for",
+            "release",
+            "tomorrow",
+            ",",
+            "fail",
+            "to",
+            "show",
+            "a",
+            "substantial",
+            "improvement",
+            "from",
+            "July",
+            "and",
+            "August",
+            "'s",
+            "near-record",
+            "deficits",
+            ".",
+        ]
+        assert fields["tags"].labels == expected_labels
+
+        if convert_to_coding_scheme is None:
             expected_labels = [
                 "O",
                 "B-PP",

--- a/tests/tagging/dataset_readers/conll2000_test.py
+++ b/tests/tagging/dataset_readers/conll2000_test.py
@@ -8,6 +8,7 @@ from tests import FIXTURES_ROOT
 
 
 class TestConll2000Reader:
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @pytest.mark.parametrize("lazy", (True, False))
     @pytest.mark.parametrize("coding_scheme", ("BIO", "BIOUL"))
     def test_read_from_file_with_deprecated_parameter(self, lazy, coding_scheme):
@@ -234,6 +235,7 @@ class TestConll2000Reader:
         ]
         assert fields["tags"].labels == expected_labels
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @pytest.mark.parametrize("lazy", (True, False))
     @pytest.mark.parametrize("convert_to_coding_scheme", (None, "BIOUL"))
     def test_read_from_file(self, lazy, convert_to_coding_scheme):

--- a/tests/tagging/dataset_readers/conll2000_test.py
+++ b/tests/tagging/dataset_readers/conll2000_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from allennlp_models.tagging import Conll2000DatasetReader
+from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import ensure_list
 
 from tests import FIXTURES_ROOT
@@ -460,3 +461,7 @@ class TestConll2000Reader:
             ".",
         ]
         assert fields["tags"].labels == expected_labels
+
+    def test_read_data_from_with_unsupported_coding_scheme(self):
+        with pytest.raises(ConfigurationError):
+            Conll2000DatasetReader(convert_to_coding_scheme="IOB100")


### PR DESCRIPTION
Related to https://github.com/allenai/allennlp/pull/4924.

This PR introduces a parameter `convert_to_coding_scheme` to `Conll2000DatasetReader`.
The context of this PR is the same as allenai/allennlp/pull/4924.