### PR TITLE
OpenIE fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `OpenIePredictor.predict_json` so it treats auxiliary verbs as verbs
+  when the language is English.
+
 ## [v2.0.0](https://github.com/allenai/allennlp-models/releases/tag/v2.0.0) - 2021-01-27
 
 ### Fixed

--- a/allennlp_models/structured_prediction/predictors/openie.py
+++ b/allennlp_models/structured_prediction/predictors/openie.py
@@ -186,9 +186,12 @@ class OpenIePredictor(Predictor):
     Used by online demo and for prediction on an input file using command line.
     """
 
-    def __init__(self, model: Model, dataset_reader: DatasetReader) -> None:
+    def __init__(
+        self, model: Model, dataset_reader: DatasetReader, language: str = "en_core_web_sm"
+    ) -> None:
         super().__init__(model, dataset_reader)
-        self._tokenizer = SpacyTokenizer(pos_tags=True)
+        self._language = language
+        self._tokenizer = SpacyTokenizer(language=language, pos_tags=True)
 
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         """
@@ -223,7 +226,11 @@ class OpenIePredictor(Predictor):
         sent_tokens = self._tokenizer.tokenize(inputs["sentence"])
 
         # Find all verbs in the input sentence
-        pred_ids = [i for (i, t) in enumerate(sent_tokens) if t.pos_ == "VERB"]
+        pred_ids = [
+            i
+            for (i, t) in enumerate(sent_tokens)
+            if t.pos_ == "VERB" or (self._language.startswith("en_") and t.pos_ == "AUX")
+        ]
 
         # Create instances
         instances = [

--- a/tests/structured_prediction/predictors/openie_test.py
+++ b/tests/structured_prediction/predictors/openie_test.py
@@ -118,3 +118,23 @@ class TestOpenIePredictor(AllenNlpTestCase):
         assert len(pred_dict) == 1
         tags = list(pred_dict.values())[0]
         assert get_predicate_text(sent_tokens, tags) == "refused to consider joining"
+
+    def test_aux_verb(self):
+        inputs = {"sentence": "Yellowstone National Park is in the United States of America."}
+
+        archive = load_archive(
+            FIXTURES_ROOT / "structured_prediction" / "srl" / "serialization" / "model.tar.gz"
+        )
+        predictor = Predictor.from_archive(archive, "open_information_extraction")
+
+        result = predictor.predict_json(inputs)
+
+        verbs = result.get("verbs")
+        assert verbs is not None
+        assert isinstance(verbs, list)
+
+        for verb in verbs:
+            tags = verb.get("tags")
+            assert tags is not None
+            assert isinstance(tags, list)
+            assert all(isinstance(tag, str) for tag in tags)


### PR DESCRIPTION
Fixes https://github.com/allenai/allennlp/issues/4943
* Fixed `OpenIePredictor.predict_json` so it treats auxiliary verbs as verbs when the language is English.