### PR TITLE
Fix prediction for models using TransformerMCReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BART model now adds a `predicted_text` field in `make_output_human_readable` that has the cleaned text corresponding to `predicted_tokens`.
 
+### Fixed
+
+- Made `label` parameter in `TransformerMCReader.text_to_instance` optional with default of `None`.
 
 ## [v2.0.1](https://github.com/allenai/allennlp-models/releases/tag/v2.0.1) - 2021-02-01
 

--- a/allennlp_models/mc/dataset_readers/transformer_mc.py
+++ b/allennlp_models/mc/dataset_readers/transformer_mc.py
@@ -44,7 +44,7 @@ class TransformerMCReader(DatasetReader):
         qid: str,
         start: str,
         alternatives: List[str],
-        label: Optional[int],
+        label: Optional[int] = None,
     ) -> Instance:
         # tokenize
         start = self._tokenizer.tokenize(start)


### PR DESCRIPTION
Hi, I stumbled upon an issue when playing with QA models, f.e.,:
```python
from allennlp_models.pretrained import load_predictor
predictor = load_predictor("mc-roberta-commonsenseqa")

question = "If I am tilting a drink toward my face, what should I do before the liquid spills over?"
alternatives = ["open mouth", "eat first", "use glass"]
predictor.predict(question, alternatives)
```

```python
(...)
     20     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
     21         return self._dataset_reader.text_to_instance(
---> 22             "no_qid", json_dict["prefix"], json_dict["alternatives"]
     23         )

TypeError: text_to_instance() missing 1 required positional argument: 'label'
```
This PR fixes the issue.