### PR TITLE
Add `ignore_loss_on_o_tags` to `CrfTagger.__init__()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add option `combine_input_fields` in `SnliDatasetReader` to support only having "non-entailment" and "entailment" as output labels.
 - Made all the models run on AllenNLP 2.1
+- Add option `ignore_loss_on_o_tags` in `CrfTagger` to set the flag outside its forward function.
 
 ### Fixed
 

--- a/allennlp_models/tagging/models/crf_tagger.py
+++ b/allennlp_models/tagging/models/crf_tagger.py
@@ -68,7 +68,7 @@ class CrfTagger(Model):
         {"tags": List, "score": float}.
         The "tags" value for the first dict in the list for each data_item will be the top
         choice, and will equal the corresponding item in output_dict['tags']
-    ignore_loss_on_o_tags : `bool`, optional (detaul=`False`)
+    ignore_loss_on_o_tags : `bool`, optional (default=`False`)
         If True, we compute the loss only for actual spans in `tags`, and not on `O` tokens.
         This is useful for computing gradients of the loss on a _single span_, for
         interpretation / attacking.

--- a/allennlp_models/tagging/models/crf_tagger.py
+++ b/allennlp_models/tagging/models/crf_tagger.py
@@ -212,7 +212,11 @@ class CrfTagger(Model):
         loss : `torch.FloatTensor`, optional
             A scalar loss to be optimised. Only computed if gold label `tags` are provided.
         """
-        ignore_loss_on_o_tags = ignore_loss_on_o_tags or self.ignore_loss_on_o_tags
+        ignore_loss_on_o_tags = (
+            ignore_loss_on_o_tags
+            if ignore_loss_on_o_tags is not None
+            else self.ignore_loss_on_o_tags
+        )
         embedded_text_input = self.text_field_embedder(tokens)
         mask = util.get_text_field_mask(tokens)
 


### PR DESCRIPTION
Context: https://github.com/allenai/allennlp/issues/5058
While `CrfTagger.forward()` has the `ignore_loss_on_o_tags` option, 
there's no way to pass the option to `forward` unless its dataset reader does.
Since I don't think `DatasetReader` is responsible for handing training parameters,
I added the option into `__init__`.