### PR TITLE
Always keep Spacy PoS tagger on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `QaNet` and `NumericallyAugmentedQaNet` models to remove bias for layers that are followed by normalization layers.
 - Updated the model cards for `rc-naqanet`, `vqa-vilbert` and `ve-vilbert`.
 - Predictors now work for the vilbert-multitask model.
+- Fixed https://github.com/allenai/allennlp/issues/5036; incoperate for tests in allennlp repo
 
 
 ## [v2.1.0](https://github.com/allenai/allennlp-models/releases/tag/v2.1.0) - 2021-02-24

--- a/allennlp_models/structured_prediction/predictors/biaffine_dependency_parser.py
+++ b/allennlp_models/structured_prediction/predictors/biaffine_dependency_parser.py
@@ -88,7 +88,7 @@ class BiaffineDependencyParserPredictor(Predictor):
     ) -> None:
         super().__init__(model, dataset_reader)
         # TODO(Mark) Make the language configurable and based on a model attribute.
-        self._tokenizer = SpacyTokenizer(language=language, pos_tags=True)
+        self._tokenizer = SpacyTokenizer(language=language)
 
     def predict(self, sentence: str) -> JsonDict:
         """

--- a/allennlp_models/structured_prediction/predictors/constituency_parser.py
+++ b/allennlp_models/structured_prediction/predictors/constituency_parser.py
@@ -68,7 +68,7 @@ class ConstituencyParserPredictor(Predictor):
         self, model: Model, dataset_reader: DatasetReader, language: str = "en_core_web_sm"
     ) -> None:
         super().__init__(model, dataset_reader)
-        self._tokenizer = SpacyTokenizer(language=language, pos_tags=True)
+        self._tokenizer = SpacyTokenizer(language=language)
 
     def predict(self, sentence: str) -> JsonDict:
         """

--- a/allennlp_models/structured_prediction/predictors/openie.py
+++ b/allennlp_models/structured_prediction/predictors/openie.py
@@ -191,7 +191,7 @@ class OpenIePredictor(Predictor):
     ) -> None:
         super().__init__(model, dataset_reader)
         self._language = language
-        self._tokenizer = SpacyTokenizer(language=language, pos_tags=True)
+        self._tokenizer = SpacyTokenizer(language=language)
 
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         """

--- a/allennlp_models/structured_prediction/predictors/srl.py
+++ b/allennlp_models/structured_prediction/predictors/srl.py
@@ -22,7 +22,7 @@ class SemanticRoleLabelerPredictor(Predictor):
     ) -> None:
         super().__init__(model, dataset_reader)
         self._language = language
-        self._tokenizer = SpacyTokenizer(language=language, pos_tags=True)
+        self._tokenizer = SpacyTokenizer(language=language)
 
     def predict(self, sentence: str) -> JsonDict:
         """

--- a/test_fixtures/generation/composed/experiment.json
+++ b/test_fixtures/generation/composed/experiment.json
@@ -3,7 +3,6 @@
     "type": "seq2seq",
     "source_tokenizer": {
       "type": "spacy",
-      "pos_tags": true,
       "parse": true,
       "ner": true
     },

--- a/test_fixtures/generation/simple/experiment.json
+++ b/test_fixtures/generation/simple/experiment.json
@@ -3,7 +3,6 @@
     "type": "seq2seq",
     "source_tokenizer": {
       "type": "spacy",
-      "pos_tags": true,
       "parse": true,
       "ner": true
     },


### PR DESCRIPTION
Fixing some fail tests in https://github.com/allenai/allennlp/pull/5066
Due to the different use of function `get_spacy_models`