### PR TITLE
Fixed bug in `experiment_from_huggingface.jsonnet` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Changed
+### Fixed
 
 - Fix bug in `experiment_from_huggingface.jsonnet` by changing `min_count` to have key `labels` instead of `answers`. Resolves failure of model checks that involve calling `_extend` in `vocabulary.py`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Fix bug in `experiment_from_huggingface.jsonnet` by changing `min_count` to have key `labels` instead of `answers`. Resolves failure of model checks that involve calling `_extend` in `vocabulary.py`
+
 
 ## [v2.2.0](https://github.com/allenai/allennlp-models/releases/tag/v2.2.0) - 2021-03-26
 

--- a/test_fixtures/vision/vilbert_ve/experiment_from_huggingface.jsonnet
+++ b/test_fixtures/vision/vilbert_ve/experiment_from_huggingface.jsonnet
@@ -22,7 +22,7 @@ local model_name = "epwalsh/bert-xsmall-dummy";
   },
   "train_data_path": "test_fixtures/vision/visual_entailment/sample_pairs.jsonl",
   "validation_data_path": "test_fixtures/vision/visual_entailment/sample_pairs.jsonl",
-  "vocabulary": {"min_count": {"answers": 2}},
+  "vocabulary": {"min_count": {"labels": 2}},
   "datasets_for_vocab_creation": ["train"],
   "model": {
     "type": "ve_vilbert_from_huggingface",


### PR DESCRIPTION
Fixed bug in `experiment_from_huggingface.jsonnet` by changing `min_count` to have key `labels` instead of `answers`. Resolves failure of model checks that involve calling `_extend` in `vocabulary.py` (Related PR: https://github.com/allenai/allennlp/pull/3644)

