### PR TITLE
Making TransformerQAPredictor compatible with interpret modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed bug in `experiment_from_huggingface.jsonnet` and `experiment.jsonnet` by changing `min_count` to have key `labels` instead of `answers`. Resolves failure of model checks that involve calling `_extend` in `vocabulary.py`
 - `TransformerQA` now outputs span probabilities as well as scores.
+- `TransformerQAPredictor` now implements `predictions_to_labeled_instances`, which is required for the interpret module.
 
 ### Added
 

--- a/allennlp_models/rc/predictors/transformer_qa.py
+++ b/allennlp_models/rc/predictors/transformer_qa.py
@@ -93,8 +93,7 @@ class TransformerQAPredictor(Predictor):
         # if `qid` is `None`, it is updated using self._next_qid
         context = json_dict["passage"] if "passage" in json_dict else json_dict["context"]
         result: List[Instance] = []
-        if qid is None:
-            question_id = self._next_qid
+        question_id = qid or self._next_qid
 
         for instance in self._dataset_reader.make_instances(
             qid=str(question_id),

--- a/allennlp_models/rc/predictors/transformer_qa.py
+++ b/allennlp_models/rc/predictors/transformer_qa.py
@@ -94,10 +94,10 @@ class TransformerQAPredictor(Predictor):
         context = json_dict["passage"] if "passage" in json_dict else json_dict["context"]
         result: List[Instance] = []
         if qid is None:
-            qid = self._next_qid
+           question_id = self._next_qid
 
         for instance in self._dataset_reader.make_instances(
-            qid=str(qid),
+            qid=str(question_id),
             question=json_dict["question"],
             answers=[],
             context=context,

--- a/allennlp_models/rc/predictors/transformer_qa.py
+++ b/allennlp_models/rc/predictors/transformer_qa.py
@@ -94,7 +94,7 @@ class TransformerQAPredictor(Predictor):
         context = json_dict["passage"] if "passage" in json_dict else json_dict["context"]
         result: List[Instance] = []
         if qid is None:
-           question_id = self._next_qid
+            question_id = self._next_qid
 
         for instance in self._dataset_reader.make_instances(
             qid=str(question_id),


### PR DESCRIPTION
* Implements `predictions_to_labeled_instances` and `_json_to_instance`. 

Fixes https://github.com/allenai/allennlp-demo/issues/679