### PR TITLE
Update pretrained.py: Quick fix to be able to load pertained_models directly to GPU.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `pretrained.load_predictor()` now allows for loading model onto GPU.
 - `VqaMeasure` now calculates correctly in the distributed case.
 - `ConllCorefScores` now calculates correctly in the distributed case.
 - `SrlEvalScorer` raises an appropriate error if run in the distributed setting.

--- a/allennlp_models/pretrained.py
+++ b/allennlp_models/pretrained.py
@@ -60,6 +60,7 @@ def get_pretrained_models() -> Dict[str, ModelCard]:
 def load_predictor(
     model_id: str,
     pretrained_models: Dict[str, ModelCard] = None,
+    cuda_device: int = -1,
     overrides: Union[str, Dict[str, Any]] = None,
 ) -> Predictor:
     """
@@ -75,5 +76,6 @@ def load_predictor(
     return Predictor.from_path(
         model_card.model_usage.archive_file,
         predictor_name=model_card.registered_predictor_name,
+        cuda_device=cuda_device,
         overrides=overrides,
     )


### PR DESCRIPTION
Quick fix to be able to load pertained_models directly to GPU.