### PR TITLE
Add way to initialize SrlBert without pretrained BERT weights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}-v2
 
     - name: Install requirements
       run: |
@@ -192,7 +192,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}-v2
 
     - name: Install requirements
       run: |
@@ -336,7 +336,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}-v2
 
     - name: Install requirements
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tests for checklist suites for SQuAD-style reading comprehension models (`bidaf`), and textual entailment models (`decomposable_attention` and `esim`).
 - Added a way to initialize the `SrlBert` model without caching/loading pretrained transformer weights.
   You need to set the `bert_model` parameter to the dictionary form of the corresponding `BertConfig` from HuggingFace.
+  See [PR #257](https://github.com/allenai/allennlp-models/pull/257) for more details.
 
 
 ## [v2.4.0](https://github.com/allenai/allennlp-models/releases/tag/v2.4.0) - 2021-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added tests for checklist suites for SQuAD-style reading comprehension models (`bidaf`), and textual entailment models (`decomposable_attention` and `esim`).
+- Added a way to initialize the `SrlBert` model without caching/loading pretrained transformer weights.
+  You need to set the `bert_model` parameter to the dictionary form of the corresponding `BertConfig` from HuggingFace.
 
 
 ## [v2.4.0](https://github.com/allenai/allennlp-models/releases/tag/v2.4.0) - 2021-04-22

--- a/test_fixtures/structured_prediction/srl/bert_srl_local_files.jsonnet
+++ b/test_fixtures/structured_prediction/srl/bert_srl_local_files.jsonnet
@@ -1,4 +1,25 @@
-local bert_model = "epwalsh/bert-xsmall-dummy";
+local bert_model = "test_fixtures/bert-xsmall-dummy";
+
+# Take from test_fixtures/bert-xsmall-dummy/config.json
+local bert_config = {
+  "architectures": [
+    "BertModel"
+  ],
+  "attention_probs_dropout_prob": 0.1,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob": 0.1,
+  "hidden_size": 20,
+  "initializer_range": 0.02,
+  "intermediate_size": 40,
+  "layer_norm_eps": 1e-12,
+  "max_position_embeddings": 512,
+  "model_type": "bert",
+  "num_attention_heads": 1,
+  "num_hidden_layers": 1,
+  "pad_token_id": 0,
+  "type_vocab_size": 2,
+  "vocab_size": 250
+};
 
 {
     "dataset_reader":{
@@ -9,7 +30,7 @@ local bert_model = "epwalsh/bert-xsmall-dummy";
     "validation_data_path": "test_fixtures/structured_prediction/srl",
     "model": {
         "type": "srl_bert",
-        "bert_model": bert_model,
+        "bert_model": bert_config,
         "embedding_dropout": 0.0
     },
     "data_loader": {


### PR DESCRIPTION
Closes https://github.com/allenai/allennlp/issues/5170.

You can avoid caching/loading pretrained BERT weights by setting the `bert_model` parameter of `SrlBert` to a dictionary that corresponds to the `BertConfig` from HuggingFace. You'll also need a local copy of the config and vocab to avoid downloads from the dataset reader, so the easiest complete work-around would look something like this:

```python
from transformers import AutoConfig
from allennlp.predictors import Predictor

transformer_model_name = "bert-base-uncased"
archive_path = "https://storage.googleapis.com/allennlp-public-models/structured-prediction-srl-bert.2020.12.15.tar.gz"

# Need copies of the transformer config and vocab in a local directory.
local_config_path = "./" + transformer_model_name + "-local"

config = AutoConfig.from_pretrained(local_config_path)

predictor = Predictor.from_path(
    archive_path,
    overrides={
        "model.bert_model": config.to_dict(),
        "dataset_reader.bert_model_name": local_config_path,
    },
)
```

You can set up the local files you need by running this:

```python
from transformers import AutoConfig, AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained(transformer_model_name)
config = AutoConfig.from_pretrained(transformer_model_name)
tokenizer.save_pretrained(tokenizer_path)
config.to_json_file(local_config_path + "/config.json")
```

This is related to https://github.com/allenai/allennlp/pull/5172, but required it's own solution since the `SrlBert` model is a bit of an oddball in that it uses the BERT model class from `transformers` directly, instead of through AllenNLP's `PretrainedTransformerEmbedder`.