### PR TITLE
Add weighting option to CopyNet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added tests for checklist suites for SQuAD-style reading comprehension models (`bidaf`), and textual entailment models (`decomposable_attention` and `esim`).
+- Added an optional "weight" parameter to `CopyNetSeq2Seq.forward()` for calculating a weighted loss instead of the simple average over the
+  the negative log likelihoods for each instance in the batch.
 
 
 ## [v2.4.0](https://github.com/allenai/allennlp-models/releases/tag/v2.4.0) - 2021-04-22

--- a/allennlp_models/generation/dataset_readers/copynet_seq2seq.py
+++ b/allennlp_models/generation/dataset_readers/copynet_seq2seq.py
@@ -157,8 +157,12 @@ class CopyNetDatasetReader(DatasetReader):
         # Parameters
 
         source_string : `str`, required
+
         target_string : `str`, optional (default = `None`)
+
         weight : `float`, optional (default = `None`)
+            An optional weight to assign to this instance when calculating the loss in
+            [CopyNetSeq2Seq.forward()](../../models/copynet_seq2seq/#forward.parameters).
 
         # Returns
 
@@ -199,7 +203,7 @@ class CopyNetDatasetReader(DatasetReader):
         fields_dict["metadata"] = MetadataField(meta_fields)
 
         if weight is not None:
-            fields_dict["weight"] = ArrayField(np.array([float(weight)]))
+            fields_dict["weight"] = ArrayField(np.array([float(weight)], dtype=np.single))
 
         return Instance(fields_dict)
 

--- a/allennlp_models/generation/dataset_readers/copynet_seq2seq.py
+++ b/allennlp_models/generation/dataset_readers/copynet_seq2seq.py
@@ -2,13 +2,13 @@ import logging
 from typing import List, Dict
 import warnings
 
-import numpy as np
+import torch
 from overrides import overrides
 
 from allennlp.common.file_utils import cached_path
 from allennlp.common.util import START_SYMBOL, END_SYMBOL
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
-from allennlp.data.fields import TextField, ArrayField, MetadataField, NamespaceSwappingField
+from allennlp.data.fields import TextField, TensorField, MetadataField, NamespaceSwappingField
 from allennlp.data.instance import Instance
 from allennlp.data.tokenizers import (
     Token,
@@ -34,7 +34,7 @@ class CopyNetDatasetReader(DatasetReader):
     - `source_tokens`: a `TextField` containing the tokenized source sentence.
        This will result in a tensor of shape `(batch_size, source_length)`.
 
-    - `source_token_ids`: an `ArrayField` of size `(batch_size, source_length)`
+    - `source_token_ids`: an `TensorField` of size `(batch_size, source_length)`
       that contains an ID for each token in the source sentence. Tokens that
       match at the lowercase level will share the same ID. If `target_tokens`
       is passed as well, these IDs will also correspond to the `target_token_ids`
@@ -57,7 +57,7 @@ class CopyNetDatasetReader(DatasetReader):
       including the `START_SYMBOL` and `END_SYMBOL`. This will result in
       a tensor of shape `(batch_size, target_length)`.
 
-    - `target_token_ids`: an `ArrayField` of size `(batch_size, target_length)`.
+    - `target_token_ids`: an `TensorField` of size `(batch_size, target_length)`.
       This is calculated in the same way as `source_token_ids`.
 
     See the "Notes" section below for a description of how these fields are used.
@@ -193,17 +193,17 @@ class CopyNetDatasetReader(DatasetReader):
             meta_fields["target_tokens"] = [y.text for y in tokenized_target[1:-1]]
             source_and_target_token_ids = self._tokens_to_ids(tokenized_source + tokenized_target)
             source_token_ids = source_and_target_token_ids[: len(tokenized_source)]
-            fields_dict["source_token_ids"] = ArrayField(np.array(source_token_ids))
+            fields_dict["source_token_ids"] = TensorField(torch.tensor(source_token_ids))
             target_token_ids = source_and_target_token_ids[len(tokenized_source) :]
-            fields_dict["target_token_ids"] = ArrayField(np.array(target_token_ids))
+            fields_dict["target_token_ids"] = TensorField(torch.tensor(target_token_ids))
         else:
             source_token_ids = self._tokens_to_ids(tokenized_source)
-            fields_dict["source_token_ids"] = ArrayField(np.array(source_token_ids))
+            fields_dict["source_token_ids"] = TensorField(torch.tensor(source_token_ids))
 
         fields_dict["metadata"] = MetadataField(meta_fields)
 
         if weight is not None:
-            fields_dict["weight"] = ArrayField(np.array([float(weight)], dtype=np.single))
+            fields_dict["weight"] = TensorField(torch.tensor(float(weight), dtype=torch.float))
 
         return Instance(fields_dict)
 

--- a/allennlp_models/generation/dataset_readers/copynet_seq2seq.py
+++ b/allennlp_models/generation/dataset_readers/copynet_seq2seq.py
@@ -146,7 +146,10 @@ class CopyNetDatasetReader(DatasetReader):
 
     @overrides
     def text_to_instance(
-        self, source_string: str, target_string: str = None
+        self,
+        source_string: str,
+        target_string: str = None,
+        weight: float = None,
     ) -> Instance:  # type: ignore
         """
         Turn raw source string and target string into an `Instance`.
@@ -155,6 +158,7 @@ class CopyNetDatasetReader(DatasetReader):
 
         source_string : `str`, required
         target_string : `str`, optional (default = `None`)
+        weight : `float`, optional (default = `None`)
 
         # Returns
 
@@ -193,6 +197,9 @@ class CopyNetDatasetReader(DatasetReader):
             fields_dict["source_token_ids"] = ArrayField(np.array(source_token_ids))
 
         fields_dict["metadata"] = MetadataField(meta_fields)
+
+        if weight is not None:
+            fields_dict["weight"] = ArrayField(np.array([float(weight)]))
 
         return Instance(fields_dict)
 

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -537,6 +537,8 @@ class CopyNetSeq2Seq(Model):
         if weight is None:
             loss = -log_likelihood.sum() / batch_size
         else:
+            if len(weight.shape) > 1:
+                weight = weight.squeeze()
             loss = -(weight @ log_likelihood) / weight.sum()
 
         return {"loss": loss}

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -185,9 +185,10 @@ class CopyNetSeq2Seq(Model):
             A tensor of shape `(batch_size, target_sequence_length)` which indicates which
             tokens in the target sequence match tokens in the source sequence.
         weight : `torch.Tensor`, optional (default = `None`)
-           A optional tensor of shape `(batch_size,)` which determines how to weight
-           each instance in the batch when calculating the loss. The default of `None`
-           is equivalent to `weights = torch.tensor([1.0] * batch_size)`.
+           A optional tensor of shape `(batch_size,)` or `(batch_size, 1)` which determines
+           how to weight each instance in the batch when calculating the loss.
+           The default of `None` is equivalent to `weights = torch.tensor([1.0] * batch_size)`,
+           which results in a simple unweighted (or equal-weighted) average.
 
         # Returns
 

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -157,6 +157,7 @@ class CopyNetSeq2Seq(Model):
         metadata: List[Dict[str, Any]],
         target_tokens: TextFieldTensors = None,
         target_token_ids: torch.Tensor = None,
+        weight: torch.Tensor = None,
     ) -> Dict[str, torch.Tensor]:
         """
         Make foward pass with decoder logic for producing the entire target sequence.
@@ -183,6 +184,10 @@ class CopyNetSeq2Seq(Model):
         target_token_ids : `torch.Tensor`, optional (default = `None`)
             A tensor of shape `(batch_size, target_sequence_length)` which indicates which
             tokens in the target sequence match tokens in the source sequence.
+        weight : `torch.Tensor`, optional (default = `None`)
+           A optional tensor of shape `(batch_size,)` which determines how to weight
+           each instance in the batch when calculating the loss. The default of `None`
+           is equivalent to `weights = torch.tensor([1.0] * batch_size)`.
 
         # Returns
 
@@ -194,7 +199,7 @@ class CopyNetSeq2Seq(Model):
 
         if target_tokens:
             state = self._init_decoder_state(state)
-            output_dict = self._forward_loss(target_tokens, target_token_ids, state)
+            output_dict = self._forward_loss(target_tokens, target_token_ids, state, weight=weight)
         else:
             output_dict = {}
 
@@ -440,6 +445,7 @@ class CopyNetSeq2Seq(Model):
         target_tokens: TextFieldTensors,
         target_token_ids: torch.Tensor,
         state: Dict[str, torch.Tensor],
+        weight: torch.Tensor = None,
     ) -> Dict[str, torch.Tensor]:
         """
         Calculate the loss against gold targets.
@@ -527,7 +533,10 @@ class CopyNetSeq2Seq(Model):
         # shape: (batch_size,)
         log_likelihood = (log_likelihoods * target_mask).sum(dim=-1)
         # The loss is the negative log-likelihood, averaged over the batch.
-        loss = -log_likelihood.sum() / batch_size
+        if weight is None:
+            loss = -log_likelihood.sum() / batch_size
+        else:
+            loss = -(weight @ log_likelihood) / batch_size
 
         return {"loss": loss}
 

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -536,7 +536,7 @@ class CopyNetSeq2Seq(Model):
         if weight is None:
             loss = -log_likelihood.sum() / batch_size
         else:
-            loss = -(weight @ log_likelihood) / batch_size
+            loss = -(weight @ log_likelihood) / weight.sum()
 
         return {"loss": loss}
 

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -539,7 +539,7 @@ class CopyNetSeq2Seq(Model):
         else:
             if len(weight.shape) > 1:
                 weight = weight.squeeze()
-            loss = -(weight @ log_likelihood) / weight.sum()
+            loss = -(weight * log_likelihood).sum() / weight.sum()
 
         return {"loss": loss}
 

--- a/tests/generation/dataset_readers/copynet_test.py
+++ b/tests/generation/dataset_readers/copynet_test.py
@@ -1,9 +1,11 @@
 import numpy as np
+import torch
 
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.common.util import ensure_list
 from allennlp.data import DatasetReader
+from allennlp.data.fields import TensorField
 from allennlp.data.vocabulary import Vocabulary, DEFAULT_OOV_TOKEN
 
 from allennlp_models.generation.dataset_readers import CopyNetDatasetReader
@@ -131,3 +133,9 @@ class TestCopyNetReader(AllenNlpTestCase):
         )
         np.testing.assert_equal(tensor.numpy(), check)
         assert tensor[1].item() != self.vocab.get_token_index(DEFAULT_OOV_TOKEN, "target_tokens")
+
+    def test_text_to_instance_with_weight(self):
+        instance = self.reader.text_to_instance("Hello,", "World!", weight=0.5)
+        assert "weight" in instance.fields
+        assert isinstance(instance.fields["weight"], TensorField)
+        assert instance.fields["weight"].tensor.dtype == torch.float


### PR DESCRIPTION
This is just a minor, general improvement to CopyNet. It adds the option to weight the loss contributions from individual instances when calculating the batch loss.