### PR TITLE
Updated version number for Roberta SST

### DIFF
--- a/allennlp_models/modelcards/roberta-sst.json
+++ b/allennlp_models/modelcards/roberta-sst.json
@@ -65,6 +65,6 @@
     "model_usage": {
         "archive_file": "stanford-sentiment-treebank-roberta.2021-03-11.tar.gz",
         "training_config": "classification/stanford_sentiment_treebank_roberta.jsonnet",
-        "install_instructions": "pip install allennlp==2.1.0 allennlp-models==2.1.0"
+        "install_instructions": "pip install allennlp==2.4.0 allennlp-models==2.4.0"
     }
 }


### PR DESCRIPTION
At https://stackoverflow.com/questions/67207658/assertion-error-while-using-stanford-sentiment-treebank-roberta-2021-03-11-tar-g?noredirect=1#comment118948223_67207658, someone pointed out that this model doesn't actually work with version 2.1.0.