### PR TITLE
add `StanfordSentimentTreeBankDatasetReader.apply_token_indexers()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [PR #257](https://github.com/allenai/allennlp-models/pull/257) for more details.
 - Added a `beam_search` parameter to the `generation` models so that a `BeamSearch` object can be specified in their configs.
 - Added a binary gender bias-mitigated RoBERTa model for SNLI.
+- Added `StanfordSentimentTreeBankDatasetReader.apply_token_indexers()` to add token_indexers rather than in `text_to_instance` 
 
 
 ## [v2.4.0](https://github.com/allenai/allennlp-models/releases/tag/v2.4.0) - 2021-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for NLVR2 visual entailment, including a data loader, two models, and training configs.
+- Added `StanfordSentimentTreeBankDatasetReader.apply_token_indexers()` to add token_indexers rather than in `text_to_instance` 
 
 ### Fixed
 
@@ -34,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [PR #257](https://github.com/allenai/allennlp-models/pull/257) for more details.
 - Added a `beam_search` parameter to the `generation` models so that a `BeamSearch` object can be specified in their configs.
 - Added a binary gender bias-mitigated RoBERTa model for SNLI.
-- Added `StanfordSentimentTreeBankDatasetReader.apply_token_indexers()` to add token_indexers rather than in `text_to_instance` 
 
 
 ## [v2.4.0](https://github.com/allenai/allennlp-models/releases/tag/v2.4.0) - 2021-04-22

--- a/allennlp_models/classification/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp_models/classification/dataset_readers/stanford_sentiment_tree_bank.py
@@ -156,4 +156,4 @@ class StanfordSentimentTreeBankDatasetReader(DatasetReader):
 
     @overrides
     def apply_token_indexers(self, instance: Instance) -> None:
-        instance.fields["tokens"]._token_indexers = self._token_indexers
+        instance.fields["tokens"].token_indexers = self._token_indexers

--- a/allennlp_models/classification/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp_models/classification/dataset_readers/stanford_sentiment_tree_bank.py
@@ -128,7 +128,7 @@ class StanfordSentimentTreeBankDatasetReader(DatasetReader):
             tokens = [make_token(x) for x in tokens]
         else:
             tokens = self._tokenizer.tokenize(" ".join(tokens))
-        text_field = TextField(tokens, token_indexers=self._token_indexers)
+        text_field = TextField(tokens)
         fields: Dict[str, Field] = {"tokens": text_field}
         if sentiment is not None:
             # 0 and 1 are negative sentiment, 2 is neutral, and 3 and 4 are positive sentiment
@@ -153,3 +153,7 @@ class StanfordSentimentTreeBankDatasetReader(DatasetReader):
                     sentiment = "1"
             fields["label"] = LabelField(sentiment)
         return Instance(fields)
+
+    @overrides
+    def apply_token_indexers(self, instance: Instance) -> None:
+        instance.fields["tokens"]._token_indexers = self._token_indexers


### PR DESCRIPTION
 To be consistent with the latest Allennlp implementation, add `token_indexers` of `TextField` in `apply_token_indexers()` rather than `text_to_instance()`.

## Issue
When num_worker >0, the error shows up: Found a TextField (tokens) with token_indexers already applied, but you're using num_workers > 0 in your data loader. Make sure your dataset reader's text_to_instance() method doesn't add any token_indexers to the TextFields it creates. Instead, the token_indexers should be added to the instances in the apply_token_indexers() method of your dataset reader (which you'll have to implement if you haven't done so already).