### PR TITLE
Add label smoothing to CopyNet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `AdversarialBiasMitigator` tests.
 - Added `adversarial-binary-gender-bias-mitigated-roberta-snli` model.
 - Added support for Flickr30k image retrieval, including a dataset reader, a model, and a training config.
+- Added `label_smoothing` parameter to `CopyNetSeq2Rel` to smooth generation targets.
 
 ### Fixed
 

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -458,7 +458,7 @@ class CopyNetSeq2Seq(Model):
                 -1, target_tokens.unsqueeze(1), 1.0 - self._label_smoothing
             )
             smoothed_targets = one_hot_targets + smoothing_value
-            generation_log_probs = -log_probs * smoothed_targets
+            generation_log_probs = log_probs * smoothed_targets
             # shape: (batch_size, 1)
             generation_log_probs = generation_log_probs.sum(-1, keepdim=True)
         else:

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -455,7 +455,7 @@ class CopyNetSeq2Seq(Model):
             # Create the smoothed targets to be multiplied with `log_probs`
             # shape: (batch_size, target_vocab_size + source_sequence_length)
             smoothed_targets = torch.full_like(log_probs, smoothing_value).scatter_(
-                -1, target_tokens.unsqueeze(1), 1.0 - self._label_smoothing + smoothing_value
+                1, target_tokens.unsqueeze(1), 1.0 - self._label_smoothing + smoothing_value
             )
             generation_log_probs = log_probs * smoothed_targets
             # shape: (batch_size, 1)

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -452,12 +452,11 @@ class CopyNetSeq2Seq(Model):
         # Now we get the generation score for the gold target token.
         if self._label_smoothing is not None and self._label_smoothing > 0.0:
             smoothing_value = self._label_smoothing / target_size
-            # Fill all the correct indices with 1 - smoothing value.
+            # Create the smoothed targets to be multiplied with `log_probs`
             # shape: (batch_size, target_vocab_size + source_sequence_length)
-            one_hot_targets = torch.zeros_like(log_probs).scatter_(
-                -1, target_tokens.unsqueeze(1), 1.0 - self._label_smoothing
+            smoothed_targets = torch.full_like(log_probs, smoothing_value).scatter_(
+                -1, target_tokens.unsqueeze(1), 1.0 - self._label_smoothing + smoothing_value
             )
-            smoothed_targets = one_hot_targets + smoothing_value
             generation_log_probs = log_probs * smoothed_targets
             # shape: (batch_size, 1)
             generation_log_probs = generation_log_probs.sum(-1, keepdim=True)

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -47,6 +47,11 @@ class CopyNetSeq2Seq(Model):
     attention : `Attention`, required
         This is used to get a dynamic summary of encoder outputs at each timestep
         when producing the "generation" scores for the target vocab.
+    label_smoothing : `float`, optional (default = `None`)
+        Whether or not to apply label smoothing to the cross-entropy loss.
+        For example, with a label smoothing value of 0.2, a 4 class classification
+        target would look like `[0.05, 0.05, 0.85, 0.05]` if the 3rd class was
+        the correct label.
     beam_search : `BeamSearch`, optional (default = `Lazy(BeamSearch)`)
         This is used to during inference to select the tokens of the decoded output sequence.
     target_embedding_dim : `int`, optional (default = `30`)
@@ -75,6 +80,7 @@ class CopyNetSeq2Seq(Model):
         source_embedder: TextFieldEmbedder,
         encoder: Seq2SeqEncoder,
         attention: Attention,
+        label_smoothing: float = None,
         beam_search: Lazy[BeamSearch] = Lazy(BeamSearch),
         target_embedding_dim: int = 30,
         copy_token: str = "@COPY@",
@@ -123,6 +129,7 @@ class CopyNetSeq2Seq(Model):
             num_embeddings=self._target_vocab_size, embedding_dim=target_embedding_dim
         )
         self._attention = attention
+        self._label_smoothing = label_smoothing
         self._input_projection_layer = Linear(
             target_embedding_dim + self.encoder_output_dim * 2, self.decoder_input_dim
         )
@@ -443,8 +450,24 @@ class CopyNetSeq2Seq(Model):
         gen_mask = (target_tokens != self._oov_index) | (target_to_source.sum(-1) == 0)
         log_gen_mask = (gen_mask + util.tiny_value_of_dtype(log_probs.dtype)).log().unsqueeze(-1)
         # Now we get the generation score for the gold target token.
-        # shape: (batch_size, 1)
-        generation_log_probs = log_probs.gather(1, target_tokens.unsqueeze(1)) + log_gen_mask
+        if self._label_smoothing is not None and self._label_smoothing > 0.0:
+            smoothing_value = self._label_smoothing / target_size
+            # Fill all the correct indices with 1 - smoothing value.
+            # shape: (batch_size, target_vocab_size + source_sequence_length)
+            one_hot_targets = torch.zeros_like(log_probs).scatter_(
+                -1, target_tokens.unsqueeze(1), 1.0 - self._label_smoothing
+            )
+            smoothed_targets = one_hot_targets + smoothing_value
+            generation_log_probs = -log_probs * smoothed_targets
+            # shape: (batch_size, 1)
+            generation_log_probs = generation_log_probs.sum(-1, keepdim=True)
+        else:
+            # Contribution to the negative log likelihood only comes from the exact indices
+            # of the targets, as the target distributions are one-hot. Here we use torch.gather
+            # to extract the indices which contribute to the loss.
+            # shape: (batch_size, 1)
+            generation_log_probs = log_probs.gather(1, target_tokens.unsqueeze(1))
+        generation_log_probs = generation_log_probs + log_gen_mask
         # ... and add the copy score to get the step log likelihood.
         # shape: (batch_size, 1 + source_sequence_length)
         combined_gen_and_copy = torch.cat((generation_log_probs, copy_log_probs), dim=-1)


### PR DESCRIPTION
This PR adds label smoothing to [`CopyNetSeq2Seq`](https://github.com/allenai/allennlp-models/blob/main/allennlp_models/generation/models/copynet_seq2seq.py). As discussed in https://github.com/allenai/allennlp/issues/5276, label smoothing is added to the generation scores only. It is mostly a re-working of the existing label smoothing code in [`sequence_cross_entropy_with_logits`](https://github.com/allenai/allennlp/blob/cf113d705b9054d329c67cf9bb29cbc3f191015d/allennlp/nn/util.py#L821-L836).

As a sanity check, I ran the code with my own model. A model with a small `label_smoothing` value reaches similar performance as a model with `label_smoothing == 0.0`. As for additional unit tests, I think a modification of [`test_get_ll_contrib`](https://github.com/allenai/allennlp-models/blob/e47da9911155c7d65bf0dfba51aed048d367e5ea/tests/generation/models/copynet_test.py#L67) might make the most sense.