### PR TITLE
Pass vocab to beam search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `adversarial-binary-gender-bias-mitigated-roberta-snli` model.
 - Added support for Flickr30k image retrieval, including a dataset reader, a model, and a training config.
 - Added `label_smoothing` parameter to `CopyNetSeq2Rel` to smooth generation targets.
+- Added `vocab` as argument to `beam_search.construct` in all `generation` models.
 
 ### Fixed
 

--- a/allennlp_models/generation/models/bart.py
+++ b/allennlp_models/generation/models/bart.py
@@ -165,7 +165,9 @@ class Bart(Model):
         if "max_decoding_steps" in kwargs:
             beam_search_extras["max_steps"] = kwargs["max_decoding_steps"]
             warnings.warn(deprecation_warning.format("max_decoding_steps"), DeprecationWarning)
-        self._beam_search = beam_search.construct(end_index=self._end_id, **beam_search_extras)
+        self._beam_search = beam_search.construct(
+            end_index=self._end_id, vocab=self.vocab, **beam_search_extras
+        )
 
         self._rouge = ROUGE(exclude_indices={self._start_id, self._pad_id, self._end_id})
         self._bleu = BLEU(exclude_indices={self._start_id, self._pad_id, self._end_id})

--- a/allennlp_models/generation/models/copynet_seq2seq.py
+++ b/allennlp_models/generation/models/copynet_seq2seq.py
@@ -161,7 +161,9 @@ class CopyNetSeq2Seq(Model):
         if "max_decoding_steps" in kwargs:
             beam_search_extras["max_steps"] = kwargs["max_decoding_steps"]
             warnings.warn(deprecation_warning.format("max_decoding_steps"), DeprecationWarning)
-        self._beam_search = beam_search.construct(end_index=self._end_index, **beam_search_extras)
+        self._beam_search = beam_search.construct(
+            end_index=self._end_index, vocab=self.vocab, **beam_search_extras
+        )
 
         initializer(self)
 

--- a/allennlp_models/generation/models/simple_seq2seq.py
+++ b/allennlp_models/generation/models/simple_seq2seq.py
@@ -118,7 +118,9 @@ class SimpleSeq2Seq(Model):
         if "max_decoding_steps" in kwargs:
             beam_search_extras["max_steps"] = kwargs["max_decoding_steps"]
             warnings.warn(deprecation_warning.format("max_decoding_steps"), DeprecationWarning)
-        self._beam_search = beam_search.construct(end_index=self._end_index, **beam_search_extras)
+        self._beam_search = beam_search.construct(
+            end_index=self._end_index, vocab=self.vocab, **beam_search_extras
+        )
 
         # Dense embedding of source vocab tokens.
         self._source_embedder = source_embedder

--- a/allennlp_models/generation/modules/seq_decoders/auto_regressive.py
+++ b/allennlp_models/generation/modules/seq_decoders/auto_regressive.py
@@ -97,7 +97,9 @@ class AutoRegressiveSeqDecoder(SeqDecoder):
         if "max_decoding_steps" in kwargs:
             beam_search_extras["max_steps"] = kwargs["max_decoding_steps"]
             warnings.warn(deprecation_warning.format("max_decoding_steps"), DeprecationWarning)
-        self._beam_search = beam_search.construct(end_index=self._end_index, **beam_search_extras)
+        self._beam_search = beam_search.construct(
+            end_index=self._end_index, vocab=self._vocab, **beam_search_extras
+        )
 
         target_vocab_size = self._vocab.get_vocab_size(self._target_namespace)
 


### PR DESCRIPTION
This is a small PR that should be considered alongside https://github.com/allenai/allennlp/pull/5321. It just passes `vocab` to all the `beam_search.construct` calls in the `generation` models.