### PR TITLE
Updating vision reader to also produce class probs and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed tests for Spacy versions greater than 3.1
 
+### Changed
+
+- Updated `VisionReader` to yield all of `RegionDetectorOutput`'s keys in processing.
+
 ## [v2.6.0](https://github.com/allenai/allennlp-models/releases/tag/v2.6.0) - 2021-07-19
 
 ### Added

--- a/allennlp_models/vision/dataset_readers/flickr30k.py
+++ b/allennlp_models/vision/dataset_readers/flickr30k.py
@@ -199,7 +199,9 @@ class Flickr30kReader(VisionReader):
                 full_file_path = os.path.join(self.data_dir, filename)
                 caption_dicts.append(get_caption_data(full_file_path))
 
-        processed_images: Iterable[Optional[Tuple[Tensor, Tensor]]]
+        processed_images: Iterable[
+            Optional[Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]]
+        ]
         filenames = [f"{caption_dict['image_id']}.jpg" for caption_dict in caption_dicts]
         try:
             processed_images = self._process_image_paths(
@@ -221,7 +223,7 @@ class Flickr30kReader(VisionReader):
         averaged_features_list = []
         coordinates_list = []
         masks_list = []
-        for features, coords in processed_images:
+        for features, coords, _, _ in processed_images:
             features_list.append(TensorField(features))
             averaged_features_list.append(torch.mean(features, dim=0))
             coordinates_list.append(TensorField(coords))

--- a/allennlp_models/vision/dataset_readers/gqa.py
+++ b/allennlp_models/vision/dataset_readers/gqa.py
@@ -133,7 +133,9 @@ class GQAReader(VisionReader):
                 )
             )
 
-            processed_images: Iterable[Optional[Tuple[Tensor, Tensor]]]
+            processed_images: Iterable[
+                Optional[Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]]
+            ]
             if self.produce_featurized_images:
                 # It would be much easier to just process one image at a time, but it's faster to process
                 # them in batches. So this code gathers up instances until it has enough to fill up a batch
@@ -170,7 +172,7 @@ class GQAReader(VisionReader):
     def text_to_instance(
         self,  # type: ignore
         question: str,
-        image: Optional[Union[str, Tuple[Tensor, Tensor]]],
+        image: Optional[Union[str, Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]]],
         answer: Optional[Dict[str, str]] = None,
         *,
         use_cache: bool = True,
@@ -195,9 +197,11 @@ class GQAReader(VisionReader):
 
         if image is not None:
             if isinstance(image, str):
-                features, coords = next(self._process_image_paths([image], use_cache=use_cache))
+                features, coords, _, _ = next(
+                    self._process_image_paths([image], use_cache=use_cache)
+                )
             else:
-                features, coords = image
+                features, coords, _, _ = image
             fields["box_features"] = ArrayField(features)
             fields["box_coordinates"] = ArrayField(coords)
             fields["box_mask"] = ArrayField(

--- a/allennlp_models/vision/dataset_readers/nlvr2.py
+++ b/allennlp_models/vision/dataset_readers/nlvr2.py
@@ -125,8 +125,12 @@ class Nlvr2Reader(VisionReader):
             blobs.append(json_blob)
 
         blob_dicts = list(self.shard_iterable(blobs))
-        processed_images1: Iterable[Optional[Tuple[Tensor, Tensor]]]
-        processed_images2: Iterable[Optional[Tuple[Tensor, Tensor]]]
+        processed_images1: Iterable[
+            Optional[Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]]
+        ]
+        processed_images2: Iterable[
+            Optional[Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]]
+        ]
         if self.produce_featurized_images:
             # It would be much easier to just process one image at a time, but it's faster to process
             # them in batches. So this code gathers up instances until it has enough to fill up a batch
@@ -169,11 +173,15 @@ class Nlvr2Reader(VisionReader):
                 yield instance
         logger.info(f"Successfully yielded {attempted_instances} instances")
 
-    def extract_image_features(self, image: Union[str, Tuple[Tensor, Tensor]], use_cache: bool):
+    def extract_image_features(
+        self,
+        image: Union[str, Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]],
+        use_cache: bool,
+    ):
         if isinstance(image, str):
-            features, coords = next(self._process_image_paths([image], use_cache=use_cache))
+            features, coords, _, _ = next(self._process_image_paths([image], use_cache=use_cache))
         else:
-            features, coords = image
+            features, coords, _, _ = image
 
         return (
             ArrayField(features),
@@ -190,8 +198,8 @@ class Nlvr2Reader(VisionReader):
         self,  # type: ignore
         identifier: Optional[str],
         hypothesis: str,
-        image1: Union[str, Tuple[Tensor, Tensor]],
-        image2: Union[str, Tuple[Tensor, Tensor]],
+        image1: Union[str, Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]],
+        image2: Union[str, Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]],
         label: bool,
         use_cache: bool = True,
     ) -> Instance:

--- a/allennlp_models/vision/dataset_readers/vgqa.py
+++ b/allennlp_models/vision/dataset_readers/vgqa.py
@@ -139,7 +139,9 @@ class VGQAReader(VisionReader):
         questions = questions[question_slice]
 
         question_dicts = list(self.shard_iterable(questions))
-        processed_images: Iterable[Optional[Tuple[Tensor, Tensor]]]
+        processed_images: Iterable[
+            Optional[Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]]
+        ]
         if self.produce_featurized_images:
             # It would be much easier to just process one image at a time, but it's faster to process
             # them in batches. So this code gathers up instances until it has enough to fill up a batch
@@ -196,7 +198,7 @@ class VGQAReader(VisionReader):
         qa_id: int,
         question: str,
         answer: Optional[str],
-        image: Union[str, Tuple[Tensor, Tensor]],
+        image: Union[str, Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]],
         use_cache: bool = True,
         keep_impossible_questions: bool = True,
     ) -> Optional[Instance]:
@@ -207,9 +209,9 @@ class VGQAReader(VisionReader):
         }
 
         if isinstance(image, str):
-            features, coords = next(self._process_image_paths([image], use_cache=use_cache))
+            features, coords, _, _ = next(self._process_image_paths([image], use_cache=use_cache))
         else:
-            features, coords = image
+            features, coords, _, _ = image
 
         fields["box_features"] = ArrayField(features)
         fields["box_coordinates"] = ArrayField(coords)

--- a/allennlp_models/vision/dataset_readers/vision_reader.py
+++ b/allennlp_models/vision/dataset_readers/vision_reader.py
@@ -2,6 +2,7 @@ import glob
 import logging
 from os import PathLike
 from typing import (
+    Any,
     Dict,
     List,
     Union,
@@ -211,60 +212,43 @@ class VisionReader(DatasetReader):
             self._region_detector.eval()  # type: ignore[attr-defined]
         return self._region_detector  # type: ignore[return-value]
 
+    def _create_cache(
+        self,
+        cache_name: str,
+        cache_dir: Optional[Union[str, PathLike]] = None,
+    ) -> MutableMapping[str, Tensor]:
+        if cache_dir is None:
+            return {}
+        os.makedirs(cache_dir, exist_ok=True)
+        return TensorCache(
+            os.path.join(cache_dir, cache_name),
+            read_only=not self.write_to_cache,
+        )
+
     @property
     def _feature_cache(self) -> MutableMapping[str, Tensor]:
-        if self._feature_cache_instance is None:
-            if self.feature_cache_dir is None:
-                self._feature_cache_instance = {}
-            else:
-                os.makedirs(self.feature_cache_dir, exist_ok=True)
-                self._feature_cache_instance = TensorCache(
-                    os.path.join(self.feature_cache_dir, "features"),
-                    read_only=not self.write_to_cache,
-                )
-
+        self._feature_cache_instance = self._create_cache("features", self.feature_cache_dir)
         return self._feature_cache_instance
 
     @property
     def _coordinates_cache(self) -> MutableMapping[str, Tensor]:
-        if self._coordinates_cache_instance is None:
-            if self.coordinates_cache_dir is None:
-                self._coordinates_cache_instance = {}
-            else:
-                os.makedirs(self.feature_cache_dir, exist_ok=True)  # type: ignore
-                self._coordinates_cache_instance = TensorCache(
-                    os.path.join(self.feature_cache_dir, "coordinates"),  # type: ignore
-                    read_only=not self.write_to_cache,
-                )
-
+        self._coordinates_cache_instance = self._create_cache(
+            "coordinates", self.coordinates_cache_dir
+        )
         return self._coordinates_cache_instance
 
     @property
     def _class_probs_cache(self) -> MutableMapping[str, Tensor]:
-        if self._class_probs_cache_instance is None:
-            if self.class_probs_cache_dir is None:
-                self._class_probs_cache_instance = {}
-            else:
-                os.makedirs(self.feature_cache_dir, exist_ok=True)  # type: ignore
-                self._class_probs_cache_instance = TensorCache(
-                    os.path.join(self.feature_cache_dir, "class_probs"),  # type: ignore
-                    read_only=not self.write_to_cache,
-                )
-
+        self._class_probs_cache_instance = self._create_cache(
+            "class_probs", self.class_probs_cache_dir
+        )
         return self._class_probs_cache_instance
 
     @property
     def _class_labels_cache(self) -> MutableMapping[str, Tensor]:
-        if self._class_labels_cache_instance is None:
-            if self.class_labels_cache_dir is None:
-                self._class_labels_cache_instance = {}
-            else:
-                os.makedirs(self.feature_cache_dir, exist_ok=True)  # type: ignore
-                self._class_labels_cache_instance = TensorCache(
-                    os.path.join(self.feature_cache_dir, "class_labels"),  # type: ignore
-                    read_only=not self.write_to_cache,
-                )
-
+        self._class_labels_cache_instance = self._create_cache(
+            "class_labels", self.class_labels_cache_dir
+        )
         return self._class_labels_cache_instance
 
     def _process_image_paths(

--- a/allennlp_models/vision/dataset_readers/vision_reader.py
+++ b/allennlp_models/vision/dataset_readers/vision_reader.py
@@ -2,7 +2,6 @@ import glob
 import logging
 from os import PathLike
 from typing import (
-    Any,
     Dict,
     List,
     Union,

--- a/allennlp_models/vision/dataset_readers/vision_reader.py
+++ b/allennlp_models/vision/dataset_readers/vision_reader.py
@@ -226,28 +226,32 @@ class VisionReader(DatasetReader):
 
     @property
     def _feature_cache(self) -> MutableMapping[str, Tensor]:
-        self._feature_cache_instance = self._create_cache("features", self.feature_cache_dir)
+        if self._feature_cache_instance is None:
+            self._feature_cache_instance = self._create_cache("features", self.feature_cache_dir)
         return self._feature_cache_instance
 
     @property
     def _coordinates_cache(self) -> MutableMapping[str, Tensor]:
-        self._coordinates_cache_instance = self._create_cache(
-            "coordinates", self.coordinates_cache_dir
-        )
+        if self._coordinates_cache_instance is None:
+            self._coordinates_cache_instance = self._create_cache(
+                "coordinates", self.coordinates_cache_dir
+            )
         return self._coordinates_cache_instance
 
     @property
     def _class_probs_cache(self) -> MutableMapping[str, Tensor]:
-        self._class_probs_cache_instance = self._create_cache(
-            "class_probs", self.class_probs_cache_dir
-        )
+        if self._class_probs_cache_instance is None:
+            self._class_probs_cache_instance = self._create_cache(
+                "class_probs", self.class_probs_cache_dir
+            )
         return self._class_probs_cache_instance
 
     @property
     def _class_labels_cache(self) -> MutableMapping[str, Tensor]:
-        self._class_labels_cache_instance = self._create_cache(
-            "class_labels", self.class_labels_cache_dir
-        )
+        if self._class_labels_cache_instance is None:
+            self._class_labels_cache_instance = self._create_cache(
+                "class_labels", self.class_labels_cache_dir
+            )
         return self._class_labels_cache_instance
 
     def _process_image_paths(

--- a/allennlp_models/vision/dataset_readers/visual_entailment.py
+++ b/allennlp_models/vision/dataset_readers/visual_entailment.py
@@ -76,7 +76,7 @@ class VisualEntailmentReader(VisionReader):
     @overrides
     def text_to_instance(
         self,  # type: ignore
-        image: Union[str, Tuple[Tensor, Tensor]],
+        image: Union[str, Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]],
         hypothesis: str,
         label: Optional[str] = None,
         *,
@@ -90,9 +90,11 @@ class VisualEntailmentReader(VisionReader):
 
         if image is not None:
             if isinstance(image, str):
-                features, coords = next(self._process_image_paths([image], use_cache=use_cache))
+                features, coords, _, _ = next(
+                    self._process_image_paths([image], use_cache=use_cache)
+                )
             else:
-                features, coords = image
+                features, coords, _, _ = image
 
             fields["box_features"] = ArrayField(features)
             fields["box_coordinates"] = ArrayField(coords)

--- a/allennlp_models/vision/dataset_readers/vqav2.py
+++ b/allennlp_models/vision/dataset_readers/vqav2.py
@@ -231,7 +231,9 @@ class VQAv2Reader(VisionReader):
         questions = questions[question_slice]
 
         question_dicts = list(self.shard_iterable(questions))
-        processed_images: Iterable[Optional[Tuple[Tensor, Tensor]]]
+        processed_images: Iterable[
+            Optional[Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]]
+        ]
         if self.produce_featurized_images:
             # It would be much easier to just process one image at a time, but it's faster to process
             # them in batches. So this code gathers up instances until it has enough to fill up a batch
@@ -279,7 +281,7 @@ class VQAv2Reader(VisionReader):
     def text_to_instance(
         self,  # type: ignore
         question: str,
-        image: Union[str, Tuple[Tensor, Tensor]],
+        image: Union[str, Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]],
         answer_counts: Optional[MutableMapping[str, int]] = None,
         *,
         use_cache: bool = True,
@@ -293,9 +295,11 @@ class VQAv2Reader(VisionReader):
 
         if image is not None:
             if isinstance(image, str):
-                features, coords = next(self._process_image_paths([image], use_cache=use_cache))
+                features, coords, _, _ = next(
+                    self._process_image_paths([image], use_cache=use_cache)
+                )
             else:
-                features, coords = image
+                features, coords, _, _ = image
 
             fields["box_features"] = ArrayField(features)
             fields["box_coordinates"] = ArrayField(coords)


### PR DESCRIPTION
`RegionDetectorOutput` also contains class probs and labels, depending on the region detector selected. The dataset readers inheriting from `VisionReader` should be able to use this information when available.