### PR TITLE
Seperate start/end token check for source and target tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Seperate start/end token check in `Seq2SeqDatasetReader` for source and target tokenizers.
+
 ## [v2.7.0](https://github.com/allenai/allennlp-models/releases/tag/v2.7.0) - 2021-09-01
 
 ### Added

--- a/allennlp_models/generation/dataset_readers/seq2seq.py
+++ b/allennlp_models/generation/dataset_readers/seq2seq.py
@@ -106,10 +106,8 @@ class Seq2SeqDatasetReader(DatasetReader):
             if source_add_start_token or source_add_end_token:
                 self._check_start_end_tokens(start_symbol, end_symbol, self._source_tokenizer)
             if (
-                target_add_start_token
-                or target_add_end_token
-                and self._target_tokenizer != self._source_tokenizer
-            ):
+                target_add_start_token or target_add_end_token
+            ) and self._target_tokenizer != self._source_tokenizer:
                 self._check_start_end_tokens(start_symbol, end_symbol, self._target_tokenizer)
         self._start_token = Token(start_symbol)
         self._end_token = Token(end_symbol)

--- a/allennlp_models/generation/dataset_readers/seq2seq.py
+++ b/allennlp_models/generation/dataset_readers/seq2seq.py
@@ -105,7 +105,11 @@ class Seq2SeqDatasetReader(DatasetReader):
         ):
             if source_add_start_token or source_add_end_token:
                 self._check_start_end_tokens(start_symbol, end_symbol, self._source_tokenizer)
-            if target_add_start_token or target_add_end_token:
+            if (
+                target_add_start_token
+                or target_add_end_token
+                and self._target_tokenizer != self._source_tokenizer
+            ):
                 self._check_start_end_tokens(start_symbol, end_symbol, self._target_tokenizer)
         self._start_token = Token(start_symbol)
         self._end_token = Token(end_symbol)


### PR DESCRIPTION
Closes https://github.com/allenai/allennlp/issues/5451 by separating the check for the start/end tokens in `Seq2SeqDatasetReader` into two independent checks, one for the source tokenizer, and one for the target tokenizer.